### PR TITLE
Export SafeAreaContext for use with contextType

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -3,7 +3,7 @@ import { StyleSheet } from 'react-native';
 import { EdgeInsets, InsetChangedEvent } from './SafeArea.types';
 import NativeSafeAreaView from './NativeSafeAreaView';
 
-const SafeAreaContext = React.createContext<EdgeInsets | null>(null);
+export const SafeAreaContext = React.createContext<EdgeInsets | null>(null);
 
 export interface SafeAreaViewProps {
   children?: React.ReactNode;


### PR DESCRIPTION
## Summary

I prefer using `static contextType` over render props in class components, personally. So we should export the raw context.

```js
import { SafeAreaContext } from 'react-native-safe-area-context';

class SomeComponent extends React.Component {
  static contextType = SafeAreaContext;

  render() {
    return <Text>{JSON.stringify(this.context)}</Text>
  }
}
```
