### PR TITLE
Handle nested providers

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { StyleSheet } from 'react-native';
+import { StyleSheet, View } from 'react-native';
 import { EdgeInsets, InsetChangedEvent } from './SafeArea.types';
 import NativeSafeAreaView from './NativeSafeAreaView';
 
@@ -10,20 +10,27 @@ export interface SafeAreaViewProps {
 }
 
 export function SafeAreaProvider({ children }: SafeAreaViewProps) {
+  let parentInsets = useParentSafeArea();
   const [insets, setInsets] = React.useState<EdgeInsets | null>(null);
   const onInsetsChange = React.useCallback((event: InsetChangedEvent) => {
     setInsets(event.nativeEvent.insets);
   }, []);
 
-  return (
-    <NativeSafeAreaView style={styles.fill} onInsetsChange={onInsetsChange}>
-      {insets !== null ? (
-        <SafeAreaContext.Provider value={insets}>
-          {children}
-        </SafeAreaContext.Provider>
-      ) : null}
-    </NativeSafeAreaView>
-  );
+  // If a provider is nested inside of another provider then we can just use
+  // the parent insets, without rendering another native safe area view
+  if (parentInsets) {
+    return <View style={styles.fill}>{children}</View>;
+  } else {
+    return (
+      <NativeSafeAreaView style={styles.fill} onInsetsChange={onInsetsChange}>
+        {insets !== null ? (
+          <SafeAreaContext.Provider value={insets}>
+            {children}
+          </SafeAreaContext.Provider>
+        ) : null}
+      </NativeSafeAreaView>
+    );
+  }
 }
 
 const styles = StyleSheet.create({
@@ -31,6 +38,10 @@ const styles = StyleSheet.create({
 });
 
 export const SafeAreaConsumer = SafeAreaContext.Consumer;
+
+function useParentSafeArea(): React.ContextType<typeof SafeAreaContext> {
+  return React.useContext(SafeAreaContext);
+}
 
 export function useSafeArea(): EdgeInsets {
   const safeArea = React.useContext(SafeAreaContext);


### PR DESCRIPTION
## Summary

People may accidentally nest SafeAreaProviders by using multiple libraries that both depend on it. While this is not great, we can handle it gracefully and let people use linters or something like that to avoid this instead.

## Test Plan

Works in this app:

```tsx
import React from 'react';
import {View, Text} from 'react-native';

import {SafeAreaProvider, useSafeArea} from 'react-native-safe-area-context';

function AppContainer() {
  return (
    <SafeAreaProvider>
      <App />
    </SafeAreaProvider>
  );
}

function App() {
  let insets = useSafeArea();

  return (
    <View style={{flex: 1, paddingTop: insets.top, alignItems: 'center'}}>
      <Text style={{fontSize: 30}}>Hello there</Text>
      <SafeAreaProvider>
        <Text style={{fontSize: 30}}>wat</Text>
      </SafeAreaProvider>
      <Text style={{fontSize: 30}}>ok</Text>
    </View>
  );
}

export default AppContainer;
```