### PR TITLE
Fix failed build if sdkVersions are not specified in Android root project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,5 @@
 def getExtOrDefault(name, defaultVaue) {
-  return rootProject.ext.get(name) ?: defaultVaue
+  return rootProject.ext.has(name) ? rootProject.ext.get(name) : defaultVaue
 }
 
 apply plugin: 'com.android.library'


### PR DESCRIPTION
## Summary
`getExtOrDefault` in `build.gradle` fails build with exception when property is not specified in root project. And default value is never used.
### Why?
`project.ext.get(name)` throws `UnknownPropertyException` if the extension does not have a property according to [documentation](https://docs.gradle.org/current/dsl/org.gradle.api.plugins.ExtraPropertiesExtension.html#org.gradle.api.plugins.ExtraPropertiesExtension:get(java.lang.String)).
### Solution
Use `project.ext.has(name)` method to check if the extension has a property and then return its value using `project.ext.get(name)`.

## Test Plan
### Check property from root project
- Run `example` project
- Check if build is fine and uses version from root project
### Check default value
- Remove `compileSdkVersion` in root project
- Check if build is fine and uses default version
