### PR TITLE
fix: Android return dp instead of px

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaView.java
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaView.java
@@ -44,14 +44,14 @@ public class SafeAreaView extends ReactViewGroup implements ViewTreeObserver.OnG
     } else {
       int rotation = mWindowManager.getDefaultDisplay().getRotation();
       float statusBarHeight = 0;
-      int resourceId = resources.getIdentifier("status_bar_height", "dimen", "android");
+      int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
       if (resourceId > 0) {
-        statusBarHeight = PixelUtil.toDIPFromPixel(resources.getDimensionPixelSize(resourceId));
+        statusBarHeight = PixelUtil.toDIPFromPixel(getResources().getDimensionPixelSize(resourceId));
       }
       float navbarHeight = 0;
-      resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
+      resourceId = getResources().getIdentifier("navigation_bar_height", "dimen", "android");
       if (resourceId > 0) {
-        navbarHeight = PixelUtil.toDIPFromPixel(resources.getDimensionPixelSize(resourceId));
+        navbarHeight = PixelUtil.toDIPFromPixel(getResources().getDimensionPixelSize(resourceId));
       }
 
       windowInsets = new EdgeInsets(

--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaView.java
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaView.java
@@ -46,12 +46,12 @@ public class SafeAreaView extends ReactViewGroup implements ViewTreeObserver.OnG
       int statusBarHeight = 0;
       int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
       if (resourceId > 0) {
-        statusBarHeight = (int) Math.round(PixelUtil.toDIPFromPixel(getResources().getDimensionPixelSize(resourceId)));
+        statusBarHeight = Math.round(PixelUtil.toDIPFromPixel(getResources().getDimensionPixelSize(resourceId)));
       }
       int navbarHeight = 0;
       resourceId = getResources().getIdentifier("navigation_bar_height", "dimen", "android");
       if (resourceId > 0) {
-        navbarHeight = (int) Math.round(PixelUtil.toDIPFromPixel(getResources().getDimensionPixelSize(resourceId)));
+        navbarHeight = Math.round(PixelUtil.toDIPFromPixel(getResources().getDimensionPixelSize(resourceId)));
       }
 
       windowInsets = new EdgeInsets(

--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaView.java
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaView.java
@@ -43,15 +43,15 @@ public class SafeAreaView extends ReactViewGroup implements ViewTreeObserver.OnG
           insets.getSystemWindowInsetLeft());
     } else {
       int rotation = mWindowManager.getDefaultDisplay().getRotation();
-      int statusBarHeight = 0;
-      int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
+      float statusBarHeight = 0;
+      int resourceId = resources.getIdentifier("status_bar_height", "dimen", "android");
       if (resourceId > 0) {
-        statusBarHeight = Math.round(PixelUtil.toDIPFromPixel(getResources().getDimensionPixelSize(resourceId)));
+        statusBarHeight = PixelUtil.toDIPFromPixel(resources.getDimensionPixelSize(resourceId));
       }
-      int navbarHeight = 0;
-      resourceId = getResources().getIdentifier("navigation_bar_height", "dimen", "android");
+      float navbarHeight = 0;
+      resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android");
       if (resourceId > 0) {
-        navbarHeight = Math.round(PixelUtil.toDIPFromPixel(getResources().getDimensionPixelSize(resourceId)));
+        navbarHeight = PixelUtil.toDIPFromPixel(resources.getDimensionPixelSize(resourceId));
       }
 
       windowInsets = new EdgeInsets(

--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaView.java
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaView.java
@@ -45,12 +45,12 @@ public class SafeAreaView extends ReactViewGroup implements ViewTreeObserver.OnG
       int statusBarHeight = 0;
       int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
       if (resourceId > 0) {
-        statusBarHeight = getResources().getDimensionPixelSize(resourceId);
+        statusBarHeight = (int) (getResources().getDimension(resourceId) / getResources().getDisplayMetrics().density);
       }
       int navbarHeight = 0;
       resourceId = getResources().getIdentifier("navigation_bar_height", "dimen", "android");
       if (resourceId > 0) {
-        navbarHeight = getResources().getDimensionPixelSize(resourceId);
+        navbarHeight = (int) (getResources().getDimension(resourceId) / getResources().getDisplayMetrics().density);
       }
 
       windowInsets = new EdgeInsets(

--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaView.java
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaView.java
@@ -9,6 +9,7 @@ import android.view.WindowInsets;
 import android.view.WindowManager;
 
 import com.facebook.infer.annotation.Assertions;
+import com.facebook.react.uimanager.PixelUtil;
 import com.facebook.react.views.view.ReactViewGroup;
 
 import androidx.annotation.Nullable;
@@ -45,12 +46,12 @@ public class SafeAreaView extends ReactViewGroup implements ViewTreeObserver.OnG
       int statusBarHeight = 0;
       int resourceId = getResources().getIdentifier("status_bar_height", "dimen", "android");
       if (resourceId > 0) {
-        statusBarHeight = (int) (getResources().getDimension(resourceId) / getResources().getDisplayMetrics().density);
+        statusBarHeight = (int) Math.round(PixelUtil.toDIPFromPixel(getResources().getDimensionPixelSize(resourceId)));
       }
       int navbarHeight = 0;
       resourceId = getResources().getIdentifier("navigation_bar_height", "dimen", "android");
       if (resourceId > 0) {
-        navbarHeight = (int) (getResources().getDimension(resourceId) / getResources().getDisplayMetrics().density);
+        navbarHeight = (int) Math.round(PixelUtil.toDIPFromPixel(getResources().getDimensionPixelSize(resourceId)));
       }
 
       windowInsets = new EdgeInsets(


### PR DESCRIPTION
## Summary

React Native uses density-independent pixels, or **dp**, as it's default unit. This will size elements so that they are roughly the same physical size on different devices. However, on Android we are returning pixels (px) instead of dp, resulting in a non-consistent look on different devices.
