### PR TITLE
fix: incorrect import of `SafeAreaView` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ class ClassComponent extends React.Component {
 Usage with `SafeAreaView`:
 
 ```js
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView } from 'react-native-safe-area-view';
 
 function SomeComponent() {
   return (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
`SafeAreaView` should be imported from `react-native-safe-area-view`, instead of `react-native-safe-area-context`.

The example code in README is incorrect, by mistake I believe

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

No test is needed