### PR TITLE
fix(build): npmignore unwanted platform-specific files

### DIFF
--- a/android/.npmignore
+++ b/android/.npmignore
@@ -1,0 +1,10 @@
+*.iml
+.DS_Store
+.gradle/
+.idea/
+.npmignore
+build/
+gradle/
+gradlew
+gradlew.bat
+local.properties

--- a/ios/.npmignore
+++ b/ios/.npmignore
@@ -1,0 +1,6 @@
+*/project.xcworkspace/
+*/xcuserdata/
+.DS_Store
+.npmignore
+Pods/
+build/

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "/src",
     "/lib",
     "/android",
-    "!/android/build",
     "/ios",
     "/*.podspec"
   ],


### PR DESCRIPTION

## Summary

Fix #24 by positively identifying directories + files we want in package.json files section, then using npmignore files to ignore unwanted platform files

## Test Plan

These is the same package.json::files +  .npmignore combo style we use in react-native-device-info to make better packages, courtesy of @Friederbluemle https://github.com/react-native-community/react-native-device-info/pull/872

```
(base) mike@kunashir:~/work/react-random/react-native-device-info (master) % cp ios/.npmignore ../react-native-safe-area-context/ios/
(base) mike@kunashir:~/work/react-random/react-native-device-info (master) % cp android/.npmignore ../react-native-safe-area-context/android/
```
