### PR TITLE
Added ellipsis in methods calls on android linking

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ Add the `SafeAreaContextPackage` class to your list of exported packages.
 protected List<ReactPackage> getPackages() {
     return Arrays.asList(
             new MainReactPackage(),
+            ...
             new SafeAreaContextPackage()
     );
 }


### PR DESCRIPTION
## Summary

Reading the docs, I found necessary add some code to difference the existence packages from new package added in android manual linking.


## Test Plan

I added ellipsis to demostrate for developer user the area to insert your code, like already used in implementations.
