### PR TITLE
Docs: linking in RN 0.60 is automatic

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,19 @@ or npm:
 npm install --save react-native-safe-area-context
 ```
 
-You then need to link the native parts of the library for the platforms you are using. The easiest way to link the library is using the CLI tool by running this command from the root of your project:
+You then need to link the native parts of the library for the platforms you are using. 
+
+#### Linking in React Native >= 0.60
+
+Linking the package is not required anymore with [Autolinking](https://github.com/react-native-community/cli/blob/master/docs/autolinking.md).
+
+- **iOS Platform:**
+
+  `$ npx pod-install`
+
+#### Linking in React Native < 0.60
+
+The easiest way to link the library is using the CLI tool by running this command from the root of your project:
 
 ```
 react-native link react-native-safe-area-context


### PR DESCRIPTION
## Summary

Linking with `react-native link` is no longer necessary in RN >= 0.60.

<img width="1242" alt="Screen Shot 2020-05-22 at 17 16 06" src="https://user-images.githubusercontent.com/497214/82681490-83c3f700-9c56-11ea-93ac-2ffee1ea9775.png">
