### PR TITLE
Fix nested SafeAreaViews

### DIFF
--- a/ios/SafeAreaView/RNCSafeAreaView.m
+++ b/ios/SafeAreaView/RNCSafeAreaView.m
@@ -45,12 +45,8 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 
 - (void)safeAreaInsetsDidChange
 {
+  [super safeAreaInsetsDidChange];
   [self invalidateSafeAreaInsets];
-}
-
-- (void)invalidateSafeAreaInsets
-{
-  [self setSafeAreaInsets:[self realOrEmulateSafeAreaInsets:self.emulateUnlessSupported]];
 }
 
 - (void)layoutSubviews
@@ -62,21 +58,23 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   }
 }
 
-- (void)updateLocalData
+- (void)invalidateSafeAreaInsets
 {
-  RNCSafeAreaViewLocalData *localData = [[RNCSafeAreaViewLocalData alloc] initWithInsets:_currentSafeAreaInsets
-                                                                                   edges:_edges];
-  [_bridge.uiManager setLocalData:localData forView:self];
-}
+  UIEdgeInsets safeAreaInsets = [self realOrEmulateSafeAreaInsets:self.emulateUnlessSupported];
 
-- (void)setSafeAreaInsets:(UIEdgeInsets)safeAreaInsets
-{
   if (UIEdgeInsetsEqualToEdgeInsetsWithThreshold(safeAreaInsets, _currentSafeAreaInsets, 1.0 / RCTScreenScale())) {
     return;
   }
 
   _currentSafeAreaInsets = safeAreaInsets;
   [self updateLocalData];
+}
+
+- (void)updateLocalData
+{
+  RNCSafeAreaViewLocalData *localData = [[RNCSafeAreaViewLocalData alloc] initWithInsets:_currentSafeAreaInsets
+                                                                                   edges:_edges];
+  [_bridge.uiManager setLocalData:localData forView:self];
 }
 
 - (void)setEmulateUnlessSupported:(BOOL)emulateUnlessSupported


### PR DESCRIPTION
## Summary

On iOS, nested safe area views do not get their padding applied. I think this is because `setSafeAreaInsets` overrides the existing selector - but we don't need to do that as we have `safeAreaInsetsDidChange`

This simplifies the logic a bit too

## Test Plan

Verify it SAVs work when nested - I did this in my personal project