### PR TITLE
Add missing UIKit import

### DIFF
--- a/ios/SafeAreaView/RNCSafeAreaViewLocalData.h
+++ b/ios/SafeAreaView/RNCSafeAreaViewLocalData.h
@@ -1,3 +1,5 @@
+#import <UIKit/UIKit.h>
+
 #import "RNCSafeAreaViewEdges.h"
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
## Summary

I've been updating this library in Expo for SDK38 and then the build failed due to `Unknown type name 'UIEdgeInsets'` error.

## Test Plan

Expo client with vendored code from v2.0.1 including this change compiled successfully. It cannot break anything 😄 
