### PR TITLE
Added forward Ref to withSafeAreaInsets

### DIFF
--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -121,7 +121,7 @@ export function useSafeAreaFrame(): Rect {
 export function withSafeAreaInsets<T>(
   WrappedComponent: React.ComponentType<T>,
 ) {
-  return React.forwardRef((props: T,ref:React.Ref<T>) => (
+  return React.forwardRef((props: T, ref: React.Ref<T>) => (
     <SafeAreaConsumer>
       {(insets) => <WrappedComponent {...props} insets={insets} ref={ref} />}
     </SafeAreaConsumer>

--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -121,11 +121,11 @@ export function useSafeAreaFrame(): Rect {
 export function withSafeAreaInsets<T>(
   WrappedComponent: React.ComponentType<T>,
 ) {
-  return (props: T) => (
+  return React.forwardRef((props: T,ref:React.Ref<T>) => (
     <SafeAreaConsumer>
-      {(insets) => <WrappedComponent {...props} insets={insets} />}
+      {(insets) => <WrappedComponent {...props} insets={insets} ref={ref} />}
     </SafeAreaConsumer>
-  );
+  ));
 }
 
 /**


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The forward ref is necessary in case the component underneath uses it.
This PR is related to the issue #108 

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


## Test Plan

I added the forwardRef to the withSafeAreaInsets, I'm not very experienced with typescript, I tried to implement the correct typing to allow to forward the ref, It should work even if you the component does not pass a ref, ref can be null, I think this typing allows it but I'm not really sure.

I had trouble running the example, as it run but entered in a loop and crashed, even before adding the forwardRef.
I did test It with the patch I included in the issue tracker before.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
