### PR TITLE
fix: use default empty style

### DIFF
--- a/src/SafeAreaView.tsx
+++ b/src/SafeAreaView.tsx
@@ -20,7 +20,7 @@ const edgeBitmaskMap: Record<Edge, number> = {
 };
 
 export function SafeAreaView({
-  style,
+  style = {},
   mode,
   edges,
   ...rest


### PR DESCRIPTION

## Summary

If `style` prop is undefined, `StyleSheet.flatten` will also return undefined. The code will dump consequently when it tries to destructure `flatStyle`:
https://github.com/th3rdwave/react-native-safe-area-context/blob/fc98fb3725daf60d568b10bcc2c291c52c06d91e/src/SafeAreaView.tsx#L44-L52

This is what I observed when using `react-native-web`.

## Test Plan

The following code should work with this PR:
```jsx
  <SafeAreaView>
    <Text>test</Text>
  </SafeAreaView>
```