### PR TITLE
Include tips for testing with enzyme in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ Use `SafeAreaInsetsContext` instead.
 
 Use `initialWindowMetrics` instead.
 
+### initialSafeAreaInsets
+
+Use `initialMetrics` instead.
+
 ## Web SSR
 
 If you are doing server side rendering on the web you can use `initialMetrics` to inject insets and frame value based on the device the user has, or simply pass zero values. Since insets measurement is async it will break rendering your page content otherwise.

--- a/README.md
+++ b/README.md
@@ -263,10 +263,6 @@ Use `SafeAreaInsetsContext` instead.
 
 Use `initialWindowMetrics` instead.
 
-### initialSafeAreaInsets
-
-Use `initialMetrics` instead.
-
 ## Web SSR
 
 If you are doing server side rendering on the web you can use `initialMetrics` to inject insets and frame value based on the device the user has, or simply pass zero values. Since insets measurement is async it will break rendering your page content otherwise.

--- a/README.md
+++ b/README.md
@@ -304,3 +304,17 @@ export function TestSafeAreaProvider() {
   );
 }
 ```
+
+### Testing With Enzyme
+
+If you are using [`enzyme`](https://github.com/enzymejs/enzyme) and testing a component that uses
+`useSafeAreaInsets` or other hooks requiring the `SafeAreaProvider`, you may need to provide
+`initialSafeAreaInsets` to ensure the `SafeAreaProvider` renders its children:
+
+```js
+const wrapper = shallow(
+  <SafeAreaProvider initialSafeAreaInsets={{ top: 0, left: 0, right: 0, bottom: 0 }}
+    <ComponentUnderTest />
+  </SafeAreaProvider>
+)
+```

--- a/README.md
+++ b/README.md
@@ -290,31 +290,20 @@ function App() {
 
 ## Testing
 
-You can use `initialMetrics` to provide mock data for frame and insets.
+When testing components nested under `SafeAreaProvider`, ensure to pass `initialMetrics` to
+provide mock data for frame and insets and ensure the provider renders its children.
 
 ```js
-export function TestSafeAreaProvider() {
+export function TestSafeAreaProvider({ children }) {
   return (
     <SafeAreaProvider
       initialMetrics={{
         frame: { x: 0, y: 0, width: 0, height: 0 },
         insets: { top: 0, left: 0, right: 0, bottom: 0 },
       }}
-    />
+    >
+      {children}
+    </SafeAreaProvider>
   );
 }
-```
-
-### Testing With Enzyme
-
-If you are using [`enzyme`](https://github.com/enzymejs/enzyme) and testing a component that uses
-`useSafeAreaInsets` or other hooks requiring the `SafeAreaProvider`, you may need to provide
-`initialSafeAreaInsets` to ensure the `SafeAreaProvider` renders its children:
-
-```js
-const wrapper = shallow(
-  <SafeAreaProvider initialSafeAreaInsets={{ top: 0, left: 0, right: 0, bottom: 0 }}
-    <ComponentUnderTest />
-  </SafeAreaProvider>
-)
 ```


### PR DESCRIPTION
## Summary

I was hoping to update the README to include the insight from [this comment](https://github.com/th3rdwave/react-native-safe-area-context/issues/31#issuecomment-601074087). My coworkers and I spent some time trying to figure out how to properly render a component under a `SafeAreaProvider` using `enzyme`. One engineer found [this comment](https://github.com/react-navigation/react-native-safe-area-view/issues/104#issuecomment-597789305) which is copied by the above comment. I figure if there are several people independently looking for answers to this across packages it may be worth calling it out in the documentation.

But of course, it may _not_ be worth including documentation for a potential edge case bound to a specific testing utility! And I do realize that [this comment](https://github.com/th3rdwave/react-native-safe-area-context/issues/31#issuecomment-564089209) mentions fixing this more holistically so I'm totally okay with just closing this PR but I didn't know if this would help users discover solutions faster in the interim?