### PR TITLE
Fix nested array styles for Web

### DIFF
--- a/src/SafeAreaView.tsx
+++ b/src/SafeAreaView.tsx
@@ -58,7 +58,7 @@ export function SafeAreaView({
         marginLeft: marginLeft + insetLeft,
       };
 
-      return [style, marginStyle];
+      return [flatStyle, marginStyle];
     } else {
       const {
         padding = 0,
@@ -77,7 +77,7 @@ export function SafeAreaView({
         paddingLeft: paddingLeft + insetLeft,
       };
 
-      return [style, paddingStyle];
+      return [flatStyle, paddingStyle];
     }
   }, [style, insets, mode, edgeBitmask]);
 


### PR DESCRIPTION
If you pass an array of styles to `SafeAreaView` (i.e. `<SafeAreaView style={[style1, style2, style3]} />`), on web this doesn't work because you end up with a nested array in the style declaration (`[[style1, style2, style3], {padding: 0}]`) which react-native-web seems to ignore that nested array.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

```js
import { SafeAreaView } from "react-native-safe-area-context";
import { StyleSheet, Text } from "react-native";

const styles = StyleSheet.create({
  container: {
    backgroundColor: "red"
  }
});

const App = () => {
  return (
    <SafeAreaView style={[styles.container]}>
      <Text>Hello World</Text>
    </SafeAreaView>
  );
}
```

* Because style is an array, the background color is ignored and won't work
* Tested with react-native-web 0.12.3