### PR TITLE
Fix pointerEvents, other props on SafeAreaView not working on Android

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewManager.java
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewManager.java
@@ -6,12 +6,12 @@ import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableArray;
 import com.facebook.react.uimanager.LayoutShadowNode;
 import com.facebook.react.uimanager.ThemedReactContext;
-import com.facebook.react.uimanager.ViewGroupManager;
 import com.facebook.react.uimanager.annotations.ReactProp;
+import com.facebook.react.views.view.ReactViewManager;
 
 import java.util.EnumSet;
 
-public class SafeAreaViewManager extends ViewGroupManager<SafeAreaView> {
+public class SafeAreaViewManager extends ReactViewManager {
   public SafeAreaViewManager() {
     super();
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Because SafeAreaViewManager extends `ViewGroupManager`, some props on `<View>` that are handled by [`ReactViewManager`](https://github.com/facebook/react-native/blob/v0.63.2/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java) and other classes that extend `ViewGroupManager` aren't handled. Notably, this includes `pointerEvents`, which can be used to make the SafeAreaView ignore taps when it's used as an overlay.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I installed a [branch](https://github.com/hsource/react-native-safe-area-context/releases/tag/v3.1.1-wanderlog.1) containing the fix to my own app.

To test this, create an instance of `<SafeAreaView style={{ flex: 1 }} pointerEvents="box-none">` that overlays a button or map. The button should be tappable and the map should be pannable.

| Before | After |
| --- | --- |
| ![Before](https://user-images.githubusercontent.com/2937410/88483920-d4d6bc80-cf1f-11ea-811b-733c10eb188d.gif) | ![After](https://user-images.githubusercontent.com/2937410/88483914-c5577380-cf1f-11ea-97d3-46e46b6dde72.gif) |