### PR TITLE
fix: readonly syntax error

### DIFF
--- a/src/SafeArea.types.ts
+++ b/src/SafeArea.types.ts
@@ -39,5 +39,5 @@ export interface NativeSafeAreaProviderProps {
 export type NativeSafeAreaViewProps = ViewProps & {
   children?: React.ReactNode;
   mode?: 'padding' | 'margin';
-  edges?: readonly Edge[];
+  readonly edges?: Edge[];
 };


### PR DESCRIPTION
## Summary
SafeArea.types.ts line 30 causing syntax error. 

Tests and TypeScript validations pass and clears syntax error in my project. 

closes #134 