### PR TITLE
Use own copy of useWindowDimensions

### DIFF
--- a/src/CompatNativeSafeAreaProvider.tsx
+++ b/src/CompatNativeSafeAreaProvider.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
-import { View, useWindowDimensions } from 'react-native';
+import { View } from 'react-native';
 import { NativeSafeAreaProviderProps } from './SafeArea.types';
+import useWindowDimensions from './useWindowDimensions';
 
 export function CompatNativeSafeAreaProvider({
   children,

--- a/src/useWindowDimensions.tsx
+++ b/src/useWindowDimensions.tsx
@@ -1,0 +1,36 @@
+import { Dimensions } from 'react-native';
+import { useEffect, useState } from 'react';
+
+type DisplayMetrics = {
+  width: number;
+  height: number;
+  scale: number;
+  fontScale: number;
+};
+
+// Copied from https://github.com/facebook/react-native/blob/8d57691a/Libraries/Utilities/useWindowDimensions.js
+// for compatibility with React Native < 0.61.
+export default function useWindowDimensions(): DisplayMetrics {
+  const [dimensions, setDimensions] = useState(() => Dimensions.get('window'));
+  useEffect(() => {
+    function handleChange({ window }: { window: DisplayMetrics }) {
+      if (
+        dimensions.width !== window.width ||
+        dimensions.height !== window.height ||
+        dimensions.scale !== window.scale ||
+        dimensions.fontScale !== window.fontScale
+      ) {
+        setDimensions(window);
+      }
+    }
+    Dimensions.addEventListener('change', handleChange);
+    // We might have missed an update between calling `get` in render and
+    // `addEventListener` in this handler, so we set it here. If there was
+    // no change, React will filter out this update as a no-op.
+    handleChange({ window: Dimensions.get('window') });
+    return () => {
+      Dimensions.removeEventListener('change', handleChange);
+    };
+  }, [dimensions]);
+  return dimensions;
+}


### PR DESCRIPTION
## Summary

As requested by @janicduplessis  [in this comment](https://github.com/th3rdwave/react-native-safe-area-context/issues/133#issuecomment-676584480).

## Test Plan

@janicduplessis I am having trouble running the example app on iOS. On startup I face error `Operator 'abs' not found`, linking to `node_modules/react-native-reanimated/ios/Nodes/REAOperatorNode.m#L94`. Does current `master` work properly for you?

I will check Android in a moment, but still opening as a draft since I am unable to verify on iOS.
