### PR TITLE
If view extends beyond window boundaries, do not add that difference to the insets

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaUtils.java
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaUtils.java
@@ -56,8 +56,8 @@ import androidx.annotation.Nullable;
 
     windowInsets.top = Math.max(windowInsets.top - visibleRect.top, 0);
     windowInsets.left = Math.max(windowInsets.left - visibleRect.left, 0);
-    windowInsets.bottom = Math.max(visibleRect.top + view.getHeight() + windowInsets.bottom - windowHeight, 0);
-    windowInsets.right = Math.max(visibleRect.left + view.getWidth() + windowInsets.right - windowWidth, 0);
+    windowInsets.bottom = Math.max(Math.min(visibleRect.top + view.getHeight() - windowHeight, 0) + windowInsets.bottom, 0);
+    windowInsets.right = Math.max(Math.min(visibleRect.left + view.getWidth() - windowWidth, 0) + windowInsets.right, 0);
     return windowInsets;
   }
 


### PR DESCRIPTION
Fixes #176

This may not be the ideal fix... I'm open to other options. Perhaps it should consider the scenario of the view extending beyond the window boundaries to simply be "invalid" and return `null`?? Perhaps there's something I'm missing in the intended behavior here?

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The problem is described in detail in #176. The short version is that, during rotation on Android there's a transitional phase where the window's dimensions have been updated according to the rotation but the view's have not, so the view might extend beyond the height or width of the window. The current calculations in `getSafeAreaInsets` were adding this difference in dimensions to the normal insets and returning extremely large insets.


## Test Plan

I have _not_ tested with a device/app that actually renders under a cutaway or home/back buttons and uses the safe area insets to lay out elements accordingly. This change seems pretty simple/safe in that regard to me, but I'm trusting reviewers/maintainers to say if it looks risky to them. (the status of the "example" app is unclear to me... it doesn't look like it actually uses `react-native-safe-area-context`??)

I _have_ tested with a "normal" device/app, and verified that rotating the device no longer produces super-large insets.


(this code could probably use a comment, but I wasn't sure if I understood it well enough to write a useful one...)