### PR TITLE
Use mavenCentral() since jcenter is shutting down

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -9,7 +9,7 @@ buildscript {
     if (project == rootProject) {
         repositories {
             google()
-            jcenter()
+            mavenCentral()
         }
         dependencies {
             classpath 'com.android.tools.build:gradle:4.1.2'
@@ -37,7 +37,7 @@ repositories {
         // All of React Native (JS, Obj-C sources, Android binaries) is installed from npm
         url "$rootDir/../node_modules/react-native/android"
     }
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
I noticed a warning that I got in my React Native project after pulling in this library:
```
WARNING:: Please remove usages of `jcenter()` Maven repository from your build scripts and migrate your build to other Maven repositories.
```

Just wanted to help out and remove `jcenter()` from this project as jcenter is shutting down.