### PR TITLE
Fix ReferenceError: React is not defined

### DIFF
--- a/jest/mock.js
+++ b/jest/mock.js
@@ -1,3 +1,5 @@
+import React from 'react'
+
 const MOCK_INITIAL_METRICS = {
   frame: {
     width: 320,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

When adding the mock to my Jest setup file following the instructions in the documentation, I get the following error when running my tests:

```error
    ReferenceError: React is not defined

      at Component (node_modules/react-native-safe-area-context/jest/mock.js:23:5)
      at renderWithHooks (node_modules/react-test-renderer/cjs/react-test-renderer.development.js:6016:18)
  
```
## Test Plan

This change makes the tests pass.