### PR TITLE
Only update local data if provider is present

### DIFF
--- a/ios/SafeAreaView/RNCSafeAreaView.m
+++ b/ios/SafeAreaView/RNCSafeAreaView.m
@@ -97,6 +97,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 
 - (void)updateLocalData
 {
+  if (_providerView == nil) {
+    return;
+  }
   RNCSafeAreaViewLocalData *localData = [[RNCSafeAreaViewLocalData alloc] initWithInsets:_currentSafeAreaInsets
                                                                                     mode:_mode
                                                                                    edges:_edges];


### PR DESCRIPTION
## Summary

When setting edges or mode, currently updateLocalData will be called before invalidateSafeAreaInsets meaning that _currentSafeAreaInsets will be zero. This in turn causes the shadow view to be updated with a padding (or margin) of zero. This in turn sometimes causes a 1 frame flicker (only reproducible on real device, not sim) where the safe area view is zero before being updated with the correct one.

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
