### PR TITLE
Fix margin mode for absolutely positioned elements

### DIFF
--- a/ios/RNCSafeAreaProvider.h
+++ b/ios/RNCSafeAreaProvider.h
@@ -6,6 +6,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface RNCSafeAreaProvider : RCTView
 
+extern NSString * const RNCSafeAreaDidChange;
+
 @property (nonatomic, copy) RCTBubblingEventBlock onInsetsChange;
 
 @end

--- a/ios/RNCSafeAreaProvider.m
+++ b/ios/RNCSafeAreaProvider.m
@@ -10,9 +10,15 @@
   BOOL _initialInsetsSent;
 }
 
+NSString * const RNCSafeAreaDidChange = @"RNCSafeAreaDidChange";
+
 - (void)safeAreaInsetsDidChange
 {
   [self invalidateSafeAreaInsets];
+  [NSNotificationCenter.defaultCenter
+   postNotificationName:RNCSafeAreaDidChange
+   object:self
+   userInfo:nil];
 }
 
 - (void)invalidateSafeAreaInsets

--- a/ios/RNCSafeAreaView.m
+++ b/ios/RNCSafeAreaView.m
@@ -47,16 +47,25 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
                                     NSStringFromUIEdgeInsets(_currentSafeAreaInsets)];
 }
 
-- (void)safeAreaInsetsDidChange
-{
-  [super safeAreaInsetsDidChange];
-  [self invalidateSafeAreaInsets];
-}
-
 - (void)didMoveToWindow
 {
+  UIView *previousProviderView = _providerView;
   _providerView = [self findNearestProvider];
+  BOOL providerViewDidChange = previousProviderView != _providerView;
+
   [self invalidateSafeAreaInsets];
+
+  if (providerViewDidChange) {
+    [NSNotificationCenter.defaultCenter
+     removeObserver:self
+     name:RNCSafeAreaDidChange
+     object:previousProviderView];
+    [NSNotificationCenter.defaultCenter
+     addObserver:self
+     selector:@selector(safeAreaProviderInsetsDidChange:)
+     name:RNCSafeAreaDidChange
+     object:_providerView];
+  }
 }
 
 - (void)invalidateSafeAreaInsets
@@ -107,6 +116,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 {
   _edges = edges;
   [self updateLocalData];
+}
+
+- (void)safeAreaProviderInsetsDidChange:(NSNotification *)notification
+{
+  [self invalidateSafeAreaInsets];
 }
 
 @end


### PR DESCRIPTION
## Summary

In `SafeAreaViewExample`, add the following change,

```diff
@@ -139,6 +139,17 @@ export default function ReactNativeSafeAreaView() {
           </ScrollView>
         </SafeAreaView>
       </View>
+      <SafeAreaView
+        style={{
+          position: 'absolute',
+          top: 100,
+          left: 0,
+          width: 100,
+          height: 100,
+          backgroundColor: 'red',
+        }}
+        mode="margin"
+      />
     </SafeAreaProvider>
   );
 }
```

Load up an iPhone simulator with a notch, and rotate the device. Observe the view becomes 'stuck'. (See videos)

https://user-images.githubusercontent.com/7275322/154671804-4b004bbb-72f5-4086-88cc-ee763731e038.mov

https://user-images.githubusercontent.com/7275322/154671828-156a24fc-599d-486a-b4f7-dacafa64b85b.mov

This is "expected" - but it'll be much more intuitive if we just use the safe area changed notifications from the provider itself, which should match Android more closely too.

Hopefully it's not too late to smack this into the v4 release - it's technically a breaking change, but if we're fast and call it a bug fix, maybe we can justify it.

## Test Plan

See above