### PR TITLE
fix: types directory

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "react-native": "src/index.tsx",
-  "types": "lib/typescript/src/index.d.ts",
+  "types": "lib/typescript/index.d.ts",
   "source": "src/index.tsx",
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
Types definitions are located in `node_modules/react-native-safe-area-context/lib/typescript`