### PR TITLE
Renamed __DEV__ (that's no longer a global) to prevent conflicts with babel-plugin-transform-define

### DIFF
--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -8,17 +8,17 @@ import type {
   Rect,
 } from './SafeArea.types';
 
-const __DEV__ = process.env.NODE_ENV !== 'production';
+const isDev = process.env.NODE_ENV !== 'production';
 
 export const SafeAreaInsetsContext = React.createContext<EdgeInsets | null>(
   null,
 );
-if (__DEV__) {
+if (isDev) {
   SafeAreaInsetsContext.displayName = 'SafeAreaInsetsContext';
 }
 
 export const SafeAreaFrameContext = React.createContext<Rect | null>(null);
-if (__DEV__) {
+if (isDev) {
   SafeAreaFrameContext.displayName = 'SafeAreaFrameContext';
 }
 


### PR DESCRIPTION
In response to https://github.com/th3rdwave/react-native-safe-area-context/issues/253, `__DEV__` was recently explicitly defined as a local variable [here](https://github.com/th3rdwave/react-native-safe-area-context/blob/main/src/SafeAreaContext.tsx#L11). That's generally fine, but some of use naive tools like [babel-plugin-transform-define](https://github.com/FormidableLabs/babel-plugin-transform-define) to rewrite globals like `__DEV__` to a constant value when bundling. 
```js
// before babel-plugin-transform-define
const __DEV__ = process.env.NODE_ENV !== 'production';

// after babel-plugin-transform-define (unfortunate)
const false = process.env.NODE_ENV !== 'production';
```
This then leads to errors like:
```
error: node_modules/react-native-safe-area-context/src/SafeAreaContext.tsx: ./node_modules/react-native-safe-area-context/src/SafeAreaContext.tsx:
Property id of VariableDeclarator expected node to be of a type ["LVal"] but instead got "BooleanLiteral"
```

This pull request simply renames `__DEV__` to `isDev` to prevent conflict, now that it's not a global anymore. Thanks!