### PR TITLE
Add ndkVersion to Android project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,6 +32,15 @@ if (isNewArchitectureEnabled()) {
 android {
     compileSdkVersion getExtOrDefault('compileSdkVersion', 30)
 
+    // Used to override the NDK path/version on internal CI or by allowing
+    // users to customize the NDK path/version from their root project (e.g. for M1 support)
+    if (rootProject.hasProperty("ndkPath")) {
+        ndkPath rootProject.ext.ndkPath
+    }
+    if (rootProject.hasProperty("ndkVersion")) {
+        ndkVersion rootProject.ext.ndkVersion
+    }
+
     defaultConfig {
         minSdkVersion getExtOrDefault('minSdkVersion', 16)
         targetSdkVersion getExtOrDefault('targetSdkVersion', 28)


### PR DESCRIPTION
When I build Android app (react native 0.68.1) using arm based MacBook Pro M1, I receive 'Unknown host CPU architecture: arm64' error. This happens because library uses default ndkVersion, but not custom ndkVersion from 'ext'. I propose include this line in the build.gradle file to use globally specified ndkVersion if exists.

p.s. The code based on react-native implementation https://github.com/facebook/react-native/blob/23b6240b256b2afb0e5efb2cef1ce27cbd0fcdf8/ReactAndroid/build.gradle#L257-L262