### PR TITLE
Update removeEventListner deprecation to just use .remove() 

### DIFF
--- a/src/useWindowDimensions.tsx
+++ b/src/useWindowDimensions.tsx
@@ -23,13 +23,13 @@ export default function useWindowDimensions(): DisplayMetrics {
         setDimensions(window);
       }
     }
-    Dimensions.addEventListener('change', handleChange);
+    const changeSubscription = Dimensions.addEventListener('change', handleChange);
     // We might have missed an update between calling `get` in render and
     // `addEventListener` in this handler, so we set it here. If there was
     // no change, React will filter out this update as a no-op.
     handleChange({ window: Dimensions.get('window') });
     return () => {
-      Dimensions.removeEventListener('change', handleChange);
+      changeSubscription.remove();
     };
   }, [dimensions]);
   return dimensions;


### PR DESCRIPTION
## Summary

Update deprecrated usage of remove. 


```
The signature '(type: "change", handler: ({ window, screen }: { window: ScaledSize; screen: ScaledSize; }) => void): void' of 'Dimensions.removeEventListener' is deprecated.ts(6387)
index.d.ts(6208, 8): The declaration was marked as deprecated here.
```


## Test Plan

I ran the code, saw the warning. I changed the code. The warning goes away. 
Also we are patch-packaging this change into our own code. 

