### PR TITLE
Add required architecture only check

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -82,6 +82,10 @@ android {
                 }
             }
         }
+
+        ndk {
+             abiFilters (*reactNativeArchitectures())
+         }
     }
 
     lintOptions{
@@ -118,6 +122,11 @@ android {
         }
     }
 }
+
+def reactNativeArchitectures() {
+     def value = project.getProperties().get("reactNativeArchitectures")
+     return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+ }
 
 repositories {
     google()


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
When you are building on android using the new architecture, required architecture check is missing. 

Running the command: `react-native run-android  --active-arch-only` will fail if you don't first build for every single arch (`react-native run-android`)


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
1. Try to run `react-native run-android  --active-arch-only` in a project that implements `react-native-safe-area-context` as a first command and it will failed with the following error:

`fcntl(): Bad file descriptor
  /Users/username/Library/Android/sdk/ndk/21.4.7075529/build/core/prebuilt-library.mk:45: *** Android NDK: Aborting    .  Stop.
Android NDK: Check that /Users/username/XX/source/XX-mob/XX/android/app/build/react-ndk/exported/x86/libfb.so exists or that its path is correct --> As I'm running just for `armeabi-v7a` x86 arch will not exist
`
