### PR TITLE
React Native 0.69.x Compatibility

### DIFF
--- a/react-native-safe-area-context.podspec
+++ b/react-native-safe-area-context.podspec
@@ -27,7 +27,7 @@ Pod::Spec.new do |s|
     "CLANG_CXX_LANGUAGE_STANDARD" => "c++17",
   }
 
-  s.dependency "React"
+  s.dependency "React-Core"
   s.dependency "RCT-Folly"
   s.dependency "RCTRequired"
   s.dependency "RCTTypeSafety"


### PR DESCRIPTION
## Summary

Updated the Podspec for iOS so that it supports the latest versions of React Native (`0.69.x`). The dependency needs to be "React-Core" now instead of "React" in order for the iOS build to succeed. Otherwise, there are undefined symbol errors.

## Test Plan

Xcode build failed when packaged with React Native `0.69.4`. With this small change, the Xcode build succeeds and the app runs successfully.
