### PR TITLE
fix: RCT_NEW_ARCH_ENABLED=0 to disable new arch

### DIFF
--- a/react-native-safe-area-context.podspec
+++ b/react-native-safe-area-context.podspec
@@ -1,6 +1,6 @@
 require 'json'
 
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED']=='1'
+fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 

--- a/react-native-safe-area-context.podspec
+++ b/react-native-safe-area-context.podspec
@@ -1,6 +1,6 @@
 require 'json'
 
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED']
+fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED']=='1'
 
 package = JSON.parse(File.read(File.join(__dir__, 'package.json')))
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

RCT_NEW_ARCH_ENABLED=0 is not working, sometimes disturb when we enable and disable the new arch

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


## Test Plan
`RCT_NEW_ARCH_ENABLED=1` enable new arch and then try to disable `RCT_NEW_ARCH_ENABLED=0` then Xcode will get an error when it will be building app

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
