### PR TITLE
fix(test): _NativeSafeAreaContext.default.getConstants is not a function

### DIFF
--- a/src/InitialWindow.native.ts
+++ b/src/InitialWindow.native.ts
@@ -1,7 +1,7 @@
 import type { Metrics } from './SafeArea.types';
 import NativeSafeAreaContext from './specs/NativeSafeAreaContext';
 
-export const initialWindowMetrics = (NativeSafeAreaContext?.getConstants()
+export const initialWindowMetrics = (NativeSafeAreaContext?.getConstants?.()
   ?.initialWindowMetrics ?? null) as Metrics | null;
 
 /**


### PR DESCRIPTION
Fixes #290 
Fixes #255 

## Summary

The reason is described in #290, it appears that the native module import comes back as `{ default: {} }`.

The fix ensures `getConstants` is only called if it's defined. When mocked, `default` is `{}` and thus `default.getConstants` is `undefined`.

## Test Plan

Verified to work in our own projects. Using it via `patch-package`

