### PR TITLE
Fix `Could not locate shadow view` errors

### DIFF
--- a/ios/RNCSafeAreaView.m
+++ b/ios/RNCSafeAreaView.m
@@ -14,7 +14,7 @@
   UIEdgeInsets _currentSafeAreaInsets;
   RNCSafeAreaViewMode _mode;
   RNCSafeAreaViewEdges _edges;
-  __weak UIView *_Nullable _providerView;
+  __weak RNCSafeAreaProvider *_Nullable _providerView;
 }
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge

--- a/ios/RNCSafeAreaView.m
+++ b/ios/RNCSafeAreaView.m
@@ -55,15 +55,20 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   [self invalidateSafeAreaInsets];
 
   if (previousProviderView != _providerView) {
-    [NSNotificationCenter.defaultCenter
-     removeObserver:self
-     name:RNCSafeAreaDidChange
-     object:previousProviderView];
-    [NSNotificationCenter.defaultCenter
-     addObserver:self
-     selector:@selector(safeAreaProviderInsetsDidChange:)
-     name:RNCSafeAreaDidChange
-     object:_providerView];
+    if (previousProviderView != nil) {
+      [NSNotificationCenter.defaultCenter
+       removeObserver:self
+       name:RNCSafeAreaDidChange
+       object:previousProviderView];
+    }
+
+    if (_providerView != nil) {
+      [NSNotificationCenter.defaultCenter
+       addObserver:self
+       selector:@selector(safeAreaProviderInsetsDidChange:)
+       name:RNCSafeAreaDidChange
+       object:_providerView];
+    }
   }
 }
 
@@ -87,16 +92,16 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
   [self updateLocalData];
 }
 
-- (UIView *)findNearestProvider
+- (nullable RNCSafeAreaProvider *)findNearestProvider
 {
   UIView *current = self.reactSuperview;
   while (current != nil) {
     if ([current isKindOfClass:RNCSafeAreaProvider.class]) {
-      return current;
+      return (RNCSafeAreaProvider *)current;
     }
     current = current.reactSuperview;
   }
-  return self;
+  return nil;
 }
 
 - (void)updateLocalData


### PR DESCRIPTION
> [native] Could not locate shadow view with tag #583, this is probably caused by a temporary inconsistency between native views and shadow views

Caused when a view is removed - presumably the shadow view is removed, and we try and update data

I could reliably reproduce it locally, and can confirm the fix works

I can't quite follow the logic here of why we fallback to using the current view when a provider cannot be found. The current view won't emit `RNCSafeAreaDidChange` events - but then I'm not clear why we even saw this bug in the first place.