### PR TITLE
chore: support Fabric on RN 0.71.0

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -99,10 +99,6 @@ repositories {
 def kotlin_version = getExtOrDefault('kotlinVersion', project.properties['RNSAC_kotlinVersion'])
 
 dependencies {
-    if (isNewArchitectureEnabled()) {
-        implementation project(":ReactAndroid")
-    } else {
-        implementation 'com.facebook.react:react-native:+'
-    }
+    implementation 'com.facebook.react:react-native:+'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 }


### PR DESCRIPTION
## Summary

Currently the Fabric build on 0.71.0 is broken. 

I introduced changes in `android/build.gradle` script that allow the project to compile (I've done the same thing in `react-native-screens` using `patch-package` and it seems to be working just fine).

Resolves #338.

**Please note** that this change drops Fabric support for older versions of React Native (Paper should work just fine), but I believe [it is acceptable](https://github.com/th3rdwave/react-native-safe-area-context#new-architecture-support).

## Test Plan

I did not migrate `fabric-example`, but this change is tested in other libs (`react-native-screens`, `react-native-svg`) and compliant to suggestions in:

* [Android's readme in RN repo](https://github.com/facebook/react-native/blob/e108e9ebf1e6c52b6eeffeb6c41f842ad95baa0d/android/README.md)
* [Road to 0.71.0 post](https://github.com/reactwg/react-native-releases/discussions/41#discussioncomment-4194847)


@janicduplessis please take a look at this