### PR TITLE
refactor: reuse 'useSafeAreaInsets' on withSafeAreaInsets

### DIFF
--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -116,11 +116,11 @@ const NO_INSETS_ERROR =
   'No safe area value available. Make sure you are rendering `<SafeAreaProvider>` at the top of your app.';
 
 export function useSafeAreaInsets(): EdgeInsets {
-  const safeArea = React.useContext(SafeAreaInsetsContext);
-  if (safeArea == null) {
+  const insets = React.useContext(SafeAreaInsetsContext);
+  if (insets == null) {
     throw new Error(NO_INSETS_ERROR);
   }
-  return safeArea;
+  return insets;
 }
 
 export function useSafeAreaFrame(): Rect {
@@ -140,16 +140,10 @@ export function withSafeAreaInsets<T>(
 ): React.ForwardRefExoticComponent<
   React.PropsWithoutRef<T> & React.RefAttributes<unknown>
 > {
-  return React.forwardRef((props: T, ref: React.Ref<unknown>) => (
-    <SafeAreaInsetsContext.Consumer>
-      {(insets) => {
-        if (insets == null) {
-          throw new Error(NO_INSETS_ERROR);
-        }
-        return <WrappedComponent {...props} insets={insets} ref={ref} />;
-      }}
-    </SafeAreaInsetsContext.Consumer>
-  ));
+  return React.forwardRef((props: T, ref: React.Ref<unknown>) => {
+    const insets = useSafeAreaInsets();
+    return <WrappedComponent {...props} insets={insets} ref={ref} />;
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary

I was profiling my App and found that the stackTrace was quite big

![image](https://user-images.githubusercontent.com/6432326/219971080-c7e43a69-85f8-43c6-bb2b-d98b32375f82.png)

Digging into the codebase i found the `withSafeAreaInsets` which renders and extra consumer.

Changed the consumer to the useContext which is the recommended approach according to the react docs and provide 1 less stack and reuse code. 

https://beta.reactjs.org/reference/react/createContext#consumer.


## Test Plan

Tested on my app the change and didn't spot any issue. AFAIK, the useContext is equivalent as the consumer so no more impact.
