### PR TITLE
fix: Cocoapods for Xcode 14.3

### DIFF
--- a/react-native-safe-area-context.podspec
+++ b/react-native-safe-area-context.podspec
@@ -14,7 +14,7 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platforms    = { :ios => "11.0", :tvos => "11.0" }
+  s.platforms    = { :ios => "12.4", :tvos => "11.0" }
 
   s.source       = { :git => "https://github.com/th3rdwave/react-native-safe-area-context.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,mm}"


### PR DESCRIPTION
## Summary
On Thursday the 30th, Apple Released Xcode 14.3

Xcode 14.3 enforce a version check that React-Native-Safe-Area-View, which supported iOS 11 as minimum version, could not be build anymore.

## Test Plan
RCT_NEW_ARCH_ENABLED=1 npx pod-install

build react-native-safe-area-context origin version (4.5.0) on Xcode 14.3
<img width="261" alt="build-failure" src="https://user-images.githubusercontent.com/95837975/229698533-adb1730a-64d1-4bb9-a894-b8ae889d3360.png">
build failure

build react-native-safe-area-context patch version as this commit on Xcode 14.3
<img width="1124" alt="build-success" src="https://user-images.githubusercontent.com/95837975/229699399-7e23849d-a5a3-482d-9135-e1058d80e139.png">
build success
