### PR TITLE
fix: 🐛 empty array sets no edges

### DIFF
--- a/ios/RNCSafeAreaViewEdges.h
+++ b/ios/RNCSafeAreaViewEdges.h
@@ -6,4 +6,5 @@ typedef NS_ENUM(NSInteger, RNCSafeAreaViewEdges) {
   RNCSafeAreaViewEdgesBottom = 0b0010,
   RNCSafeAreaViewEdgesLeft = 0b0001,
   RNCSafeAreaViewEdgesAll = 0b1111,
+  RNCSafeAreaViewEdgesNone = 0b0000,
 };

--- a/ios/RNCSafeAreaViewEdges.m
+++ b/ios/RNCSafeAreaViewEdges.m
@@ -11,7 +11,7 @@ RCT_MULTI_ENUM_CONVERTER(
       @"bottom" : @(RNCSafeAreaViewEdgesBottom),
       @"left" : @(RNCSafeAreaViewEdgesLeft),
     }),
-    RNCSafeAreaViewEdgesAll,
+    RNCSafeAreaViewEdgesNone,
     integerValue);
 
 @end


### PR DESCRIPTION
## Summary

As #204 states, providing an empty array as edges to the SafeAreaView component should result into no edges being set. When the edges prop is omitted, all edges should still be set as default


## Test Plan

I've tested this on an iPhone 14 Pro

```Typescript
<SafeAreaView edges={[]} style={{ backgroundColor: 'blue', flex: 1 }}>
      <View style={{ backgroundColor: 'red', flex: 1 }} />
 </SafeAreaView>
```

| no edges (defaults to all) | edges={['bottom']} | edges={[]} |
|--------|--------|--------|
| ![IMG_3120](https://user-images.githubusercontent.com/60874935/234274620-6bfb83b1-07f7-4a67-ab7d-f824696a9d81.PNG) | ![IMG_3121](https://user-images.githubusercontent.com/60874935/234274612-2344c7a8-a734-4a83-9104-8399b4e77539.PNG) | ![IMG_3119](https://user-images.githubusercontent.com/60874935/234274627-cc06bb26-23f3-4192-8c52-4afead2f6516.PNG) | 

