### PR TITLE
fix:Compatible with version 0.72

### DIFF
--- a/common/cpp/react/renderer/components/safeareacontext/RNCSafeAreaViewState.h
+++ b/common/cpp/react/renderer/components/safeareacontext/RNCSafeAreaViewState.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <react/renderer/components/safeareacontext/Props.h>
-#include <react/renderer/graphics/Geometry.h>
+#include <react/renderer/graphics/Float.h>
 #include <vector>
 
 #ifdef ANDROID

--- a/common/cpp/react/renderer/components/safeareacontext/RNCSafeAreaViewState.h
+++ b/common/cpp/react/renderer/components/safeareacontext/RNCSafeAreaViewState.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <react/renderer/components/safeareacontext/Props.h>
-#include <react/renderer/graphics/Float.h>
+#include <react/renderer/graphics/RectangleEdges.h>
 #include <vector>
 
 #ifdef ANDROID


### PR DESCRIPTION


## Summary
The Geometry.h file is deprecated and will be removed in the next version of React Native.