### PR TITLE
set namespace in build.gradle

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,7 @@ if (isNewArchitectureEnabled()) {
 }
 
 android {
+    namespace "com.th3rdwave.safeareacontext"
     compileSdkVersion getExtOrDefault('compileSdkVersion', 30)
 
     // Used to override the NDK path/version on internal CI or by allowing

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,6 +1,4 @@
 
 <manifest
-	xmlns:android="http://schemas.android.com/apk/res/android"
-	package="com.th3rdwave.safeareacontext">
-
+	xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Resolves #392 

> Setting the namespace via a source AndroidManifest.xml's package attribute is deprecated.
> Please instead set the namespace (or testNamespace) in the module's build.gradle file, as described here: 
> https://developer.android.com/studio/build/configure-app-module#set-namespace

More context: https://github.com/react-native-community/discussions-and-proposals/issues/671
> 