### PR TITLE
fix(minor): type declaration path in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "lib/commonjs/index.js",
   "module": "lib/module/index.js",
   "react-native": "src/index.tsx",
-  "types": "lib/typescript/index.d.ts",
+  "types": "lib/typescript/src/index.d.ts",
   "source": "src/index.tsx",
   "sideEffects": false,
   "files": [


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
After v4.6.0, the types declaration isn't found. So adjusted the declaration path in package.json to `lib/typescript/src/index.d.ts`

<img width="569" alt="image" src="https://github.com/th3rdwave/react-native-safe-area-context/assets/24909879/ab1a27e2-9417-4e28-99c0-874a429615ad">


## Test Plan
N/A
<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
