### PR TITLE
Update safe area frame when keyboard shows/hides

### DIFF
--- a/ios/Fabric/RNCSafeAreaProviderComponentView.mm
+++ b/ios/Fabric/RNCSafeAreaProviderComponentView.mm
@@ -24,6 +24,15 @@ using namespace facebook::react;
   if (self = [super initWithFrame:frame]) {
     static const auto defaultProps = std::make_shared<const RNCSafeAreaProviderProps>();
     _props = defaultProps;
+
+    [NSNotificationCenter.defaultCenter addObserver:self
+                                           selector:@selector(invalidateSafeAreaInsets)
+                                               name:UIKeyboardDidShowNotification
+                                             object:nil];
+    [NSNotificationCenter.defaultCenter addObserver:self
+                                           selector:@selector(invalidateSafeAreaInsets)
+                                               name:UIKeyboardDidHideNotification
+                                             object:nil];
   }
 
   return self;

--- a/ios/RNCSafeAreaProvider.m
+++ b/ios/RNCSafeAreaProvider.m
@@ -10,6 +10,21 @@
   BOOL _initialInsetsSent;
 }
 
+- (instancetype)init
+{
+  if ((self = [super init])) {
+    [NSNotificationCenter.defaultCenter addObserver:self
+                                           selector:@selector(invalidateSafeAreaInsets)
+                                               name:UIKeyboardDidShowNotification
+                                             object:nil];
+    [NSNotificationCenter.defaultCenter addObserver:self
+                                           selector:@selector(invalidateSafeAreaInsets)
+                                               name:UIKeyboardDidHideNotification
+                                             object:nil];
+  }
+  return self;
+}
+
 - (void)safeAreaInsetsDidChange
 {
   [self invalidateSafeAreaInsets];


### PR DESCRIPTION
When the keyboard shows/hides in pageSheet/formSheet presentation styles, the modal is pushed partially up, so the `y` position changes