### PR TITLE
Update podspec to tvOS 12.4

### DIFF
--- a/react-native-safe-area-context.podspec
+++ b/react-native-safe-area-context.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platforms    = { :ios => "12.4", :tvos => "11.0" }
+  s.platforms    = { :ios => "12.4", :tvos => "12.4" }
 
   s.source       = { :git => "https://github.com/th3rdwave/react-native-safe-area-context.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,mm}"


### PR DESCRIPTION
Fixes an issue when building for tvOS and Fabric enabled.



## Summary

Fix an issue when building for tvOS and Fabric enabled:

```
› Compiling react-native-safe-area-context Pods/react-native-safe-area-context-tvOS » RNCSafeAreaViewShadowNode.cpp

❌  (ios/Pods/Headers/Public/React-Fabric/react/renderer/components/view/conversions.h:111:39)

  109 |     case YGUnitPercent:
  110 |       return base.has_value()
> 111 |           ? std::optional<Float>(base.value() * floatFromYogaFloat(value.value))
      |                                       ^ 'value' is unavailable: introduced in tvOS 12.0
  112 |           : std::optional<Float>();
  113 |     case YGUnitAuto:
  114 |       return {};

```

## Test Plan

https://github.com/react-native-tvos/TVReanimated should build without any need for a patch to this module.
