### PR TITLE
Fix invalid area insets on Android

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaUtils.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaUtils.kt
@@ -6,7 +6,6 @@ import android.view.ViewGroup
 import android.view.WindowInsets
 import androidx.annotation.RequiresApi
 import java.lang.IllegalArgumentException
-import kotlin.math.max
 import kotlin.math.min
 
 @RequiresApi(Build.VERSION_CODES.R)
@@ -72,10 +71,18 @@ fun getSafeAreaInsets(view: View): EdgeInsets? {
   val visibleRect = android.graphics.Rect()
   view.getGlobalVisibleRect(visibleRect)
   return EdgeInsets(
-      top = max(windowInsets.top - visibleRect.top, 0f),
-      right = max(min(visibleRect.left + view.width - windowWidth, 0f) + windowInsets.right, 0f),
-      bottom = max(min(visibleRect.top + view.height - windowHeight, 0f) + windowInsets.bottom, 0f),
-      left = max(windowInsets.left - visibleRect.left, 0f))
+      top = maxOf(windowInsets.top - visibleRect.top, windowInsets.top, 0f),
+      right =
+          maxOf(
+              min(visibleRect.left + view.width - windowWidth, 0f) + windowInsets.right,
+              windowInsets.right,
+              0f),
+      bottom =
+          maxOf(
+              min(visibleRect.top + view.height - windowHeight, 0f) + windowInsets.bottom,
+              windowInsets.bottom,
+              0f),
+      left = maxOf(windowInsets.left - visibleRect.left, windowInsets.left, 0f))
 }
 
 fun getFrame(rootView: ViewGroup, view: View): Rect? {

--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaUtils.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaUtils.kt
@@ -6,7 +6,6 @@ import android.view.ViewGroup
 import android.view.WindowInsets
 import androidx.annotation.RequiresApi
 import java.lang.IllegalArgumentException
-import kotlin.math.min
 
 @RequiresApi(Build.VERSION_CODES.R)
 private fun getRootWindowInsetsCompatR(rootView: View): EdgeInsets? {
@@ -35,7 +34,7 @@ private fun getRootWindowInsetsCompatM(rootView: View): EdgeInsets? {
       // want to be consistent with iOS. Using the min value makes sure we
       // never get the keyboard offset while still working with devices that
       // hide the navigation bar.
-      bottom = min(insets.systemWindowInsetBottom, insets.stableInsetBottom).toFloat(),
+      bottom = minOf(insets.systemWindowInsetBottom, insets.stableInsetBottom).toFloat(),
       left = insets.systemWindowInsetLeft.toFloat())
 }
 
@@ -74,12 +73,12 @@ fun getSafeAreaInsets(view: View): EdgeInsets? {
       top = maxOf(windowInsets.top - visibleRect.top, windowInsets.top, 0f),
       right =
           maxOf(
-              min(visibleRect.left + view.width - windowWidth, 0f) + windowInsets.right,
+              minOf(visibleRect.left + view.width - windowWidth, 0f) + windowInsets.right,
               windowInsets.right,
               0f),
       bottom =
           maxOf(
-              min(visibleRect.top + view.height - windowHeight, 0f) + windowInsets.bottom,
+              minOf(visibleRect.top + view.height - windowHeight, 0f) + windowInsets.bottom,
               windowInsets.bottom,
               0f),
       left = maxOf(windowInsets.left - visibleRect.left, windowInsets.left, 0f))


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
Hi! 
During the work on `react-native-screens` I found a strange bug in `useSafeAreaInsets` hook on Android side. 
Currently, area insets received by `useSafeAreaInsets` seem to be invalid. On the first render, as the hook is sending proper values (I assume it uses `getSafeAreaInsets` method on getting initial window metrics) it sends incorrect inset (which is 0) after a while.

This Pull Request introduces a fix that adds takes `windowInsets` into comparing values of each inset when the native side reports negative or zero value. It fixes possibly #364 and #234 (if flickering is caused by insets being equal to 0).

<details>
<img width="1405" alt="useSafeAreaInsets-Before" src="https://github.com/th3rdwave/react-native-safe-area-context/assets/23281839/58ecd5ff-382a-40d5-8b33-f646a632b8f9">
<summary>Before</summary>
</details>
<details><summary>After</summary>
<img width="1415" alt="useSafeAreaInsets-After" src="https://github.com/th3rdwave/react-native-safe-area-context/assets/23281839/b5596aaf-82e5-4409-9a2a-5b32ff3885e7">
</details>

## Test Plan
1. Wrap your code with `<SafeAreaInsetsContext.Consumer>` and `<SafeAreaProvider>`
2. Try to use `useSafeAreaInsets().top` and then simply `console.log` it.
3. Launch the android emulator.

Before adding the changes it should return `24` on the initial render and `0` on the next render. After adding the changes it should only return `24`, which is expected value. 