### PR TITLE
Proposal of imperative API - useSafeAreaGetLatestWindowMetrics

### DIFF
--- a/src/SafeArea.types.ts
+++ b/src/SafeArea.types.ts
@@ -27,6 +27,8 @@ export interface Metrics {
   frame: Rect;
 }
 
+export type NullableMetrics = { [K in keyof Metrics]: Metrics[K] | null };
+
 export type InsetChangedEvent = NativeSyntheticEvent<Metrics>;
 
 export type InsetChangeNativeCallback = (event: InsetChangedEvent) => void;

--- a/src/SafeArea.types.ts
+++ b/src/SafeArea.types.ts
@@ -27,7 +27,10 @@ export interface Metrics {
   frame: Rect;
 }
 
-export type NullableMetrics = { [K in keyof Metrics]: Metrics[K] | null };
+export type InitialMetricsState = {
+  insets: EdgeInsets | null;
+  frame: Rect;
+};
 
 export type InsetChangedEvent = NativeSyntheticEvent<Metrics>;
 

--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -91,9 +91,22 @@ export function SafeAreaProvider({
     [setFrame, setInsets],
   );
 
+  // Add flex to the style if it doesn't have it.
+  const flexedStyle = React.useMemo(() => {
+    const flatStyle = StyleSheet.flatten(style) || {};
+    if ('flex' in flatStyle === false) {
+      return {
+        ...flatStyle,
+        flex: 1,
+      };
+    }
+
+    return style;
+  }, [style]);
+
   return (
     <NativeSafeAreaProvider
-      style={[styles.fill, style]}
+      style={flexedStyle}
       onInsetsChange={onInsetsChange}
       {...others}
     >
@@ -107,10 +120,6 @@ export function SafeAreaProvider({
     </NativeSafeAreaProvider>
   );
 }
-
-const styles = StyleSheet.create({
-  fill: { flex: 1 },
-});
 
 function useParentSafeAreaInsets(): EdgeInsets | null {
   return React.useContext(SafeAreaInsetsContext);

--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -31,99 +31,95 @@ export interface SafeAreaProviderProps extends ViewProps {
   initialSafeAreaInsets?: EdgeInsets | null;
 }
 
-export const SafeAreaProvider = React.memo(
-  ({
-    children,
-    initialMetrics,
-    initialSafeAreaInsets,
-    style,
-    ...others
-  }: SafeAreaProviderProps) => {
-    const parentInsets = useParentSafeAreaInsets();
-    const parentFrame = useParentSafeAreaFrame();
-    const [insets, setInsets] = React.useState<EdgeInsets | null>(
-      initialMetrics?.insets ?? initialSafeAreaInsets ?? parentInsets ?? null,
-    );
-    const [frame, setFrame] = React.useState<Rect>(
-      initialMetrics?.frame ??
-        parentFrame ?? {
-          // Backwards compat so we render anyway if we don't have frame.
-          x: 0,
-          y: 0,
-          width: Dimensions.get('window').width,
-          height: Dimensions.get('window').height,
-        },
-    );
-    const onInsetsChange = React.useCallback(
-      (event: InsetChangedEvent) => {
-        const {
-          nativeEvent: { frame: nextFrame, insets: nextInsets },
-        } = event;
-
-        setFrame((frame) => {
-          if (
-            // Backwards compat with old native code that won't send frame.
-            nextFrame &&
-            (nextFrame.height !== frame.height ||
-              nextFrame.width !== frame.width ||
-              nextFrame.x !== frame.x ||
-              nextFrame.y !== frame.y)
-          ) {
-            return nextFrame;
-          } else {
-            return frame;
-          }
-        });
-
-        setInsets((insets) => {
-          if (
-            !insets ||
-            nextInsets.bottom !== insets.bottom ||
-            nextInsets.left !== insets.left ||
-            nextInsets.right !== insets.right ||
-            nextInsets.top !== insets.top
-          ) {
-            return nextInsets;
-          } else {
-            return insets;
-          }
-        });
+export function SafeAreaProvider({
+  children,
+  initialMetrics,
+  initialSafeAreaInsets,
+  style,
+  ...others
+}: SafeAreaProviderProps) {
+  const parentInsets = useParentSafeAreaInsets();
+  const parentFrame = useParentSafeAreaFrame();
+  const [insets, setInsets] = React.useState<EdgeInsets | null>(
+    initialMetrics?.insets ?? initialSafeAreaInsets ?? parentInsets ?? null,
+  );
+  const [frame, setFrame] = React.useState<Rect>(
+    initialMetrics?.frame ??
+      parentFrame ?? {
+        // Backwards compat so we render anyway if we don't have frame.
+        x: 0,
+        y: 0,
+        width: Dimensions.get('window').width,
+        height: Dimensions.get('window').height,
       },
-      [setFrame, setInsets],
-    );
+  );
+  const onInsetsChange = React.useCallback(
+    (event: InsetChangedEvent) => {
+      const {
+        nativeEvent: { frame: nextFrame, insets: nextInsets },
+      } = event;
 
-    // Add flex to the style if it doesn't have it.
-    const flexedStyle = React.useMemo(() => {
-      const flatStyle = StyleSheet.flatten(style) || {};
-      if ('flex' in flatStyle === false) {
-        return {
-          ...flatStyle,
-          flex: 1,
-        };
-      }
+      setFrame((frame) => {
+        if (
+          // Backwards compat with old native code that won't send frame.
+          nextFrame &&
+          (nextFrame.height !== frame.height ||
+            nextFrame.width !== frame.width ||
+            nextFrame.x !== frame.x ||
+            nextFrame.y !== frame.y)
+        ) {
+          return nextFrame;
+        } else {
+          return frame;
+        }
+      });
 
-      return style;
-    }, [style]);
+      setInsets((insets) => {
+        if (
+          !insets ||
+          nextInsets.bottom !== insets.bottom ||
+          nextInsets.left !== insets.left ||
+          nextInsets.right !== insets.right ||
+          nextInsets.top !== insets.top
+        ) {
+          return nextInsets;
+        } else {
+          return insets;
+        }
+      });
+    },
+    [setFrame, setInsets],
+  );
 
-    return (
-      <NativeSafeAreaProvider
-        style={flexedStyle}
-        onInsetsChange={onInsetsChange}
-        {...others}
-      >
-        {insets != null ? (
-          <SafeAreaFrameContext.Provider value={frame}>
-            <SafeAreaInsetsContext.Provider value={insets}>
-              {children}
-            </SafeAreaInsetsContext.Provider>
-          </SafeAreaFrameContext.Provider>
-        ) : null}
-      </NativeSafeAreaProvider>
-    );
-  },
-);
+  // Add flex to the style if it doesn't have it.
+  const flexedStyle = React.useMemo(() => {
+    const flatStyle = StyleSheet.flatten(style) || {};
+    if ('flex' in flatStyle === false) {
+      return {
+        ...flatStyle,
+        flex: 1,
+      };
+    }
 
-SafeAreaProvider.displayName = 'SafeAreaProvider';
+    return style;
+  }, [style]);
+
+  return (
+    <NativeSafeAreaProvider
+      style={flexedStyle}
+      onInsetsChange={onInsetsChange}
+      {...others}
+    >
+      {insets != null ? (
+        <SafeAreaFrameContext.Provider value={frame}>
+          <SafeAreaInsetsContext.Provider value={insets}>
+            {children}
+          </SafeAreaInsetsContext.Provider>
+        </SafeAreaFrameContext.Provider>
+      ) : null}
+    </NativeSafeAreaProvider>
+  );
+}
 
 function useParentSafeAreaInsets(): EdgeInsets | null {
   return React.useContext(SafeAreaInsetsContext);

--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -5,7 +5,7 @@ import type {
   EdgeInsets,
   InsetChangedEvent,
   Metrics,
-  NullableMetrics,
+  InitialMetricsState,
   Rect,
 } from './SafeArea.types';
 
@@ -24,7 +24,7 @@ if (isDev) {
 }
 
 export const SafeAreaGetLatestWindowMetricsContext = React.createContext<
-  (() => NullableMetrics) | null
+  (() => InitialMetricsState | Metrics) | null
 >(null);
 if (isDev) {
   SafeAreaGetLatestWindowMetricsContext.displayName =

--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -123,9 +123,7 @@ export const SafeAreaProvider = React.memo(
   },
 );
 
-if (isDev) {
-  SafeAreaProvider.displayName = 'SafeAreaProvider';
-}
+SafeAreaProvider.displayName = 'SafeAreaProvider';
 
 function useParentSafeAreaInsets(): EdgeInsets | null {
   return React.useContext(SafeAreaInsetsContext);

--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -59,28 +59,36 @@ export function SafeAreaProvider({
         nativeEvent: { frame: nextFrame, insets: nextInsets },
       } = event;
 
-      if (
-        // Backwards compat with old native code that won't send frame.
-        nextFrame &&
-        (nextFrame.height !== frame.height ||
-          nextFrame.width !== frame.width ||
-          nextFrame.x !== frame.x ||
-          nextFrame.y !== frame.y)
-      ) {
-        setFrame(nextFrame);
-      }
+      setFrame((frame) => {
+        if (
+          // Backwards compat with old native code that won't send frame.
+          nextFrame &&
+          (nextFrame.height !== frame.height ||
+            nextFrame.width !== frame.width ||
+            nextFrame.x !== frame.x ||
+            nextFrame.y !== frame.y)
+        ) {
+          return nextFrame;
+        } else {
+          return frame;
+        }
+      });
 
-      if (
-        !insets ||
-        nextInsets.bottom !== insets.bottom ||
-        nextInsets.left !== insets.left ||
-        nextInsets.right !== insets.right ||
-        nextInsets.top !== insets.top
-      ) {
-        setInsets(nextInsets);
-      }
+      setInsets((insets) => {
+        if (
+          !insets ||
+          nextInsets.bottom !== insets.bottom ||
+          nextInsets.left !== insets.left ||
+          nextInsets.right !== insets.right ||
+          nextInsets.top !== insets.top
+        ) {
+          return nextInsets;
+        } else {
+          return insets;
+        }
+      });
     },
-    [frame, insets],
+    [setFrame, setInsets],
   );
 
   return (

--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -91,22 +91,9 @@ export function SafeAreaProvider({
     [setFrame, setInsets],
   );
 
-  // Add flex to the style if it doesn't have it.
-  const flexedStyle = React.useMemo(() => {
-    const flatStyle = StyleSheet.flatten(style) || {};
-    if ('flex' in flatStyle === false) {
-      return {
-        ...flatStyle,
-        flex: 1,
-      };
-    }
-
-    return style;
-  }, [style]);
-
   return (
     <NativeSafeAreaProvider
-      style={flexedStyle}
+      style={StyleSheet.compose(styles.fill, style)}
       onInsetsChange={onInsetsChange}
       {...others}
     >
@@ -120,6 +107,10 @@ export function SafeAreaProvider({
     </NativeSafeAreaProvider>
   );
 }
+
+const styles = StyleSheet.create({
+  fill: { flex: 1 },
+});
 
 function useParentSafeAreaInsets(): EdgeInsets | null {
   return React.useContext(SafeAreaInsetsContext);

--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -5,6 +5,7 @@ import type {
   EdgeInsets,
   InsetChangedEvent,
   Metrics,
+  NullableMetrics,
   Rect,
 } from './SafeArea.types';
 
@@ -23,11 +24,7 @@ if (isDev) {
 }
 
 export const SafeAreaGetLatestWindowMetricsContext = React.createContext<
-  | (() => {
-      insets: EdgeInsets | null;
-      frame: Rect | null;
-    })
-  | null
+  (() => NullableMetrics) | null
 >(null);
 if (isDev) {
   SafeAreaGetLatestWindowMetricsContext.displayName =

--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -123,7 +123,9 @@ export const SafeAreaProvider = React.memo(
   },
 );
 
-SafeAreaProvider.displayName = 'SafeAreaProvider';
+if (isDev) {
+  SafeAreaProvider.displayName = 'SafeAreaProvider';
+}
 
 function useParentSafeAreaInsets(): EdgeInsets | null {
   return React.useContext(SafeAreaInsetsContext);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The name I matched to `initialWindowMetrics` that is exported. The hook name is kind of long.

This offers a way for users to get the latest window metrics.

Usage:

```
const getLatestWindowMetrics = useSafeAreaGetLatestWindowMetrics();

// getLatestWindowMetrics is now stable and can be used in effects, worklets, etc, without worrying to re-render.
```


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Just a proposal for now. If accepted will add tests.
