### PR TITLE
chore: resolve ViewProps type import

### DIFF
--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
-import { Dimensions, StyleSheet } from 'react-native';
-import type { ViewProps } from 'react-native';
+import { Dimensions, StyleSheet, type ViewProps } from 'react-native';
 import { NativeSafeAreaProvider } from './NativeSafeAreaProvider';
 import type {
   EdgeInsets,

--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
-import { Dimensions, StyleSheet, ViewProps } from 'react-native';
+import { Dimensions, StyleSheet } from 'react-native';
+import type { ViewProps } from 'react-native';
 import { NativeSafeAreaProvider } from './NativeSafeAreaProvider';
 import type {
   EdgeInsets,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

`SafeAreaContext.ts` contains an import for `ViewProps` that does not meet the TypeScript v5 `verbatimModuleSyntax` rule. It is now imported as `type`.


## Test Plan

These changes do not affect testing.
