### PR TITLE
 Extends mock capabilities and doc how to enable Babel parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -302,6 +302,29 @@ export function TestSafeAreaProvider({ children }) {
 }
 ```
 
+#### Enabling Babel Parsing for Modules
+
+While trying to use this mock, a frequently encountered error is:
+
+```js
+SyntaxError: Cannot use import statement outside a module.
+```
+
+This issue arises due to the use of the import statement. To resolve it, you need to permit Babel to parse the file.
+
+By default, [Jest does not parse files located within the node_modules folder](<(https://jestjs.io/docs/configuration#transformignorepatterns-arraystring)>).
+
+However, you can modify this behavior as outlined in the Jest documentation on [`transformIgnorePatterns` customization](https://jestjs.io/docs/tutorial-react-native#transformignorepatterns-customization).
+If you're using a preset, like the one from [react-native](https://github.com/facebook/react-native/blob/main/packages/react-native/jest-preset.js), you should update your Jest configuration to include `react-native-safe-area-context` as shown below:
+
+```js
+transformIgnorePatterns: [
+  'node_modules/(?!((jest-)?react-native|@react-native(-community)?|react-native-safe-area-context)/)',
+];
+```
+
+This adjustment ensures Babel correctly parses modules, avoiding the aforementioned syntax error.
+
 ## Contributing
 
 See the [Contributing Guide](CONTRIBUTING.md)

--- a/jest/mock.tsx
+++ b/jest/mock.tsx
@@ -23,18 +23,18 @@ const RNSafeAreaContext = jest.requireActual('react-native-safe-area-context');
 export default {
   ...RNSafeAreaContext,
   initialWindowMetrics: MOCK_INITIAL_METRICS,
-  useSafeAreaInsets: () => {
+  useSafeAreaInsets: jest.fn(() => {
     return (
       useContext(RNSafeAreaContext.SafeAreaInsetsContext) ??
       MOCK_INITIAL_METRICS.insets
     );
-  },
-  useSafeAreaFrame: () => {
+  }),
+  useSafeAreaFrame: jest.fn(() => {
     return (
       useContext(RNSafeAreaContext.SafeAreaFrameContext) ??
       MOCK_INITIAL_METRICS.frame
     );
-  },
+  }),
   // Provide a simpler implementation with default values.
   SafeAreaProvider: ({ children, initialMetrics }: SafeAreaProviderProps) => {
     return (


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

### Extends mock capabilities
 Use `jest.fn` on `useSafeAreaInsets` and `useSafeAreaFrame` to allow the use of Mock Functions method as shown below:

```js
import {useSafeAreaInsets} from 'react-native-safe-area-context';

const mockedUseSafeAreaInsets = jest.mocked(useSafeAreaInsets);
mockedUseSafeAreaInsets.mockImplementationOnce()
```

### Improve documentation: Enabling Babel Parsing for Modules
Add a few lines to describe how to parse the mock file using jest config `transformIgnorePatterns`

```js
transformIgnorePatterns: [
  'node_modules/(?!((jest-)?react-native|@react-native(-community)?|react-native-safe-area-context)/)',
];
```
## Test Plan

Tested linking my react-native-safe-are-context fork as the dependency on my project:
`"react-native-safe-area-context": "git+https://github.com/LucasGarcez/react-native-safe-area-context.git#chore-improve-build-in-mock"`
