### PR TITLE
fix(android): enable buildFeatures.buildConfig for android gradle plugin 8+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,6 +42,9 @@ android {
     def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
     if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
         namespace "com.th3rdwave.safeareacontext"
+        buildFeatures {
+            buildConfig true
+        }
     }
 
     compileSdkVersion getExtOrDefault('compileSdkVersion', 30)


### PR DESCRIPTION

## Summary

Upcoming react-native 0.73+ includes android gradle plugin 8+ which needs namespace in build.gradle but also needs buildFeatures.buildConfig enabled as well

It is not sufficient to enable this at the top-level app build.gradle, specific modules that use it (such as those that implement new architecture, it seems) must also enable it at the module level

This change was necessary and is in-use in my work app via patch-package as I work through android-gradle-plugin 8+ issues in prep for react-native 0.73 launching for everyone

It is similar to changes I needed to do as react-native-firebase maintainer --> https://github.com/invertase/react-native-firebase/commit/b52d0ce6723c077190618641ce0f33ced9fd4090


## Test Plan

With apologies, you have to alter an app that integrates this module to use android gradle plugin 8, it's difficult to do that in repos I'm proposing these changes in because bumping to android gradle plugin 8 requries a large amount of transitive dependency changes in CI

I have integrated this in an app and tested it, and done similar work as maintainer of react-native-firebase, react-native-netinfo and react-native-device-info, and I'm now pushing these out to the repos

Cheers