### PR TITLE
chore: remove deprecated web API

### DIFF
--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -90,7 +90,7 @@ export function SafeAreaProvider({
 
   return (
     <NativeSafeAreaProvider
-      style={StyleSheet.compose(styles.fill, style)}
+      style={[styles.fill, style]}
       onInsetsChange={onInsetsChange}
       {...others}
     >


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

On web, we get the warning `StyleSheet.compose(a, b) is deprecated; use array syntax, i.e., [a,b].` because apparently this API is deprecated.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
