### PR TITLE
fix(#439): remove deprecated FabricViewStateManager class usage

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaContextPackage.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaContextPackage.kt
@@ -30,6 +30,7 @@ class SafeAreaContextPackage : TurboReactPackage() {
               moduleClass.name,
               true,
               reactModule.needsEagerInit,
+              /** TODO remove the parameter once support for RN < 0.73 is dropped */
               reactModule.hasConstants,
               reactModule.isCxxModule,
               TurboModule::class.java.isAssignableFrom(moduleClass))

--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewEdges.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewEdges.kt
@@ -1,7 +1,5 @@
 package com.th3rdwave.safeareacontext
 
-import java.util.*
-
 enum class SafeAreaViewEdgeModes {
   OFF,
   ADDITIVE,

--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewLocalData.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewLocalData.kt
@@ -1,7 +1,5 @@
 package com.th3rdwave.safeareacontext
 
-import java.util.*
-
 data class SafeAreaViewLocalData(
     val insets: EdgeInsets,
     val mode: SafeAreaViewMode,

--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewManager.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewManager.kt
@@ -10,7 +10,6 @@ import com.facebook.react.uimanager.annotations.ReactProp
 import com.facebook.react.viewmanagers.RNCSafeAreaViewManagerInterface
 import com.facebook.react.views.view.ReactViewGroup
 import com.facebook.react.views.view.ReactViewManager
-import java.util.*
 
 @ReactModule(name = SafeAreaViewManager.REACT_CLASS)
 class SafeAreaViewManager : ReactViewManager(), RNCSafeAreaViewManagerInterface<SafeAreaView> {
@@ -64,7 +63,7 @@ class SafeAreaViewManager : ReactViewManager(), RNCSafeAreaViewManagerInterface<
       props: ReactStylesDiffMap?,
       stateWrapper: StateWrapper?
   ): Any? {
-    (view as SafeAreaView).fabricViewStateManager.setStateWrapper(stateWrapper)
+    (view as SafeAreaView).setStateWrapper(stateWrapper)
     return null
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

closes #439 

FabricStateViewManager is deprecated in RN core and it should be migrated just to direct usage of StateWrapper
(it should be safe to use it even with older versions of RN)

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

- go to `example` folder
- run the packager with `yarn start`
- build the app with `yarn android`
