### PR TITLE
Fix the `pointerEvents` prop on SafeAreaProvider (fixes #432)

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaProviderManager.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaProviderManager.kt
@@ -4,28 +4,29 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.ThemedReactContext
 import com.facebook.react.uimanager.UIManagerHelper
-import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.viewmanagers.RNCSafeAreaProviderManagerDelegate
 import com.facebook.react.viewmanagers.RNCSafeAreaProviderManagerInterface
+import com.facebook.react.views.view.ReactViewGroup
+import com.facebook.react.views.view.ReactViewManager
 
 @ReactModule(name = SafeAreaProviderManager.REACT_CLASS)
 class SafeAreaProviderManager :
-    ViewGroupManager<SafeAreaProvider>(), RNCSafeAreaProviderManagerInterface<SafeAreaProvider> {
+    ReactViewManager(), RNCSafeAreaProviderManagerInterface<ReactViewGroup> {
   private val mDelegate = RNCSafeAreaProviderManagerDelegate(this)
 
   override fun getDelegate() = mDelegate
 
   override fun getName() = REACT_CLASS
 
-  public override fun createViewInstance(context: ThemedReactContext) = SafeAreaProvider(context)
+  override fun createViewInstance(context: ThemedReactContext) = SafeAreaProvider(context)
 
   override fun getExportedCustomDirectEventTypeConstants() =
       mutableMapOf(
           InsetsChangeEvent.EVENT_NAME to mutableMapOf("registrationName" to "onInsetsChange"))
 
-  override fun addEventEmitters(reactContext: ThemedReactContext, view: SafeAreaProvider) {
+  override fun addEventEmitters(reactContext: ThemedReactContext, view: ReactViewGroup) {
     super.addEventEmitters(reactContext, view)
-    view.setOnInsetsChangeHandler(::handleOnInsetsChange)
+    (view as? SafeAreaProvider)?.setOnInsetsChangeHandler(::handleOnInsetsChange)
   }
 
   companion object {

--- a/src/specs/NativeSafeAreaProvider.ts
+++ b/src/specs/NativeSafeAreaProvider.ts
@@ -1,6 +1,7 @@
 import type {
   DirectEventHandler,
   Double,
+  WithDefault,
 } from 'react-native/Libraries/Types/CodegenTypes';
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { ViewProps, HostComponent } from 'react-native';
@@ -20,8 +21,13 @@ export type Event = Readonly<{
   }>;
 }>;
 
+// @ts-ignore
 export interface NativeProps extends ViewProps {
   onInsetsChange?: DirectEventHandler<Event, 'paperInsetsChange'>;
+  pointerEvents?: WithDefault<
+    'box-none' | 'none' | 'box-only' | 'auto',
+    'auto'
+  >;
 }
 
 export default codegenNativeComponent<NativeProps>(


### PR DESCRIPTION
## Summary

This PR fixes #432, where the `pointerEvents` prop has no effect when applied to the `SafeAreaProvider`. I share the same use-case as the creator of the issue: I wish to use a `SafeAreaProvider` as part of an overlay, where touch events should be passed to views underneath it, as is expected when setting `pointerEvents="box-none"`.

It seems the behavior described was working until the library was migrated to the new architecture. Here are my findings:
* When running with paper, all props are set via the codegen-created `RNCSafeAreaProviderManagerDelegate#setProperty` method. This method will invoke the appropriate `@ReactProp` setter method defined in its corresponding ViewManager.
* If the `setProperty` method does not include a case to handle a prop, it will not be passed to the ViewManager. Note that react-native _does_ provide cases for most `View` props with the [BaseViewManagerInterface](https://github.com/facebook/react-native/blob/9ba3bc99e496d9e4d246445d63b68b0692b5fcab/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BaseViewManagerInterface.java#L20). However, `pointerEvents` is not included.
* In order to add the case during codegen, I simply add the `pointerEvents` prop to the `NativeProps` specs definition. Unfortunately, because the definition requires a specific format to pass codegen, it also clashes with the inherited `ViewProps`. I add a `@ts-ignore` comment as a workaround.
* Lastly, I update the `SafeAreaProviderManager` to inherit from `ReactViewManager` to handle the newly defined prop.

## Test Plan

As a test, I modified the example app by styling a `SafeAreaProvider` with `StyleSheet.absoluteFill`, and placing a Touchable button underneath/behind the view. When adding `pointerEvents="none"` to the `SafeAreaProvider`, the button can be pressed with this fix. Without this fix, the button cannot be pressed.