### PR TITLE
feat: add visionOS support

### DIFF
--- a/react-native-safe-area-context.podspec
+++ b/react-native-safe-area-context.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
 
   s.authors      = package['author']
   s.homepage     = package['homepage']
-  s.platforms    = { :ios => "12.4", :tvos => "12.4" }
+  s.platforms    = { :ios => "12.4", :tvos => "12.4", :visionos => "1.0" }
 
   s.source       = { :git => "https://github.com/th3rdwave/react-native-safe-area-context.git", :tag => "v#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,mm}"


### PR DESCRIPTION

## Summary

This PR adds visionOS support

## Test Plan

1. Init a new visionOS app (using v0.73.3) as safe-area is not working properly on nightly
2. Add `safe-area` from commit 

Related PR: https://github.com/software-mansion/react-native-screens/pull/2025
