### PR TITLE
Fix no rendered content on CarPlay

### DIFF
--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -100,7 +100,7 @@ export function SafeAreaProvider({
             {children}
           </SafeAreaInsetsContext.Provider>
         </SafeAreaFrameContext.Provider>
-      ) : null}
+      ) : children}
     </NativeSafeAreaProvider>
   );
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
When having the app opened on CarPlay only, there are no safe area insets, resulting in the provider just returning `null`. Just returning the children instead does the trick. This should fix #135