### PR TITLE
Do not specify paperName for event `onInsetsChanged`

### DIFF
--- a/src/specs/NativeSafeAreaProvider.ts
+++ b/src/specs/NativeSafeAreaProvider.ts
@@ -21,7 +21,7 @@ export type Event = Readonly<{
 }>;
 
 export interface NativeProps extends ViewProps {
-  onInsetsChange?: DirectEventHandler<Event, 'paperInsetsChange'>;
+  onInsetsChange?: DirectEventHandler<Event>;
 }
 
 export default codegenNativeComponent<NativeProps>(


### PR DESCRIPTION
## Summary

Library is currently failing to work on 0.74.0-RC2 due to the library accidentally (?) specifying a paper event name for the `onInsetsChange` event.
The logic in core has changed here: https://github.com/facebook/react-native/commit/76613ec4cd0379649a1cca9c0079b8e6bcdc2663

As the paper event name is not used at all in native code, it's safe to remove entirely.

## Test Plan

| Before | After |
| ------ | ----- |
| ![Screenshot_1709911266](https://github.com/th3rdwave/react-native-safe-area-context/assets/3001957/bf85690e-54ba-4bd0-83da-4940532c5d90) | ![Screenshot_1709911093](https://github.com/th3rdwave/react-native-safe-area-context/assets/3001957/8f2e56c0-d95d-4341-9740-e53192154872) |


