### PR TITLE
update build.gradle to fix #478

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -8,7 +8,7 @@ buildscript {
 
     dependencies {
         classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
-        classpath("com.android.tools.build:gradle:7.3.1")
+        classpath("com.android.tools.build:gradle")
         classpath("com.diffplug.spotless:spotless-plugin-gradle:6.11.0")
     }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This removes the hardcoded gradle plugin version (7.3.1) so that it uses the gradle plugin from the root project that uses this library.

## Test Plan
Just include this library in a react native app that uses 0.73+ version of react native and run the app