### PR TITLE
fix: added run recalculation for safe_area when window did become visible

### DIFF
--- a/ios/RNCSafeAreaProvider.m
+++ b/ios/RNCSafeAreaProvider.m
@@ -26,6 +26,10 @@
                                            selector:@selector(invalidateSafeAreaInsets)
                                                name:UIKeyboardDidChangeFrameNotification
                                              object:nil];
+    [NSNotificationCenter.defaultCenter addObserver:self
+                                           selector:@selector(invalidateSafeAreaInsets)
+                                               name:UIWindowDidBecomeVisibleNotification
+                                             object:nil];
 #endif
   }
   return self;


### PR DESCRIPTION
 Added run recalculation for safe_area when window did become visible

## Summary

We found missed scenario when we have to run recalculation for safe_area. In case we open before native modal and then   put our app into background mode. After restore it from background and close this modal we see old values for safe_area. We need to run recalculation to cover this scenario.

Native modal partially cover screen and in this case safe_area is reduced a little bit by iOS.

<img width="404" alt="Screenshot 2024-03-08 at 15 32 09" src="https://github.com/th3rdwave/react-native-safe-area-context/assets/109741896/d18c4d31-23e8-4eb3-9e68-fde45dc0407b">
