### PR TITLE
fix: check arch to decide if module is turbomodule

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaContextPackage.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaContextPackage.kt
@@ -33,7 +33,7 @@ class SafeAreaContextPackage : TurboReactPackage() {
               /** TODO remove the parameter once support for RN < 0.73 is dropped */
               reactModule.hasConstants,
               reactModule.isCxxModule,
-              TurboModule::class.java.isAssignableFrom(moduleClass))
+              BuildConfig.IS_NEW_ARCHITECTURE_ENABLED)
     }
     return ReactModuleInfoProvider { reactModuleInfoMap }
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

PR adding check for arch to decide if module is turbomodule since `TurboModule::class.java.isAssignableFrom(moduleClass)` should not be used anymore. It works since the behavior has been restored: https://github.com/facebook/react-native/issues/43213 but I think it is better to be prepared if it would be changed somewhere in the future.


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
