### PR TITLE
Prevent from crashing with null cannot be cast to non-null type `kotlin.Any`

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaContextModule.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaContextModule.kt
@@ -13,8 +13,8 @@ class SafeAreaContextModule(reactContext: ReactApplicationContext?) :
     return NAME
   }
 
-  public override fun getTypedExportedConstants(): Map<String, Any> {
-    return MapBuilder.of<String, Any>("initialWindowMetrics", getInitialWindowMetrics() as Any)
+  public override fun getTypedExportedConstants(): Map<String, Any?> {
+    return mapOf("initialWindowMetrics" to getInitialWindowMetrics())
   }
 
   private fun getInitialWindowMetrics(): Map<String, Any>? {


### PR DESCRIPTION
## Summary

It's possible for the `getInitialWindowMetrics` method to return `null`, which can cause crashes if we force cast it to `Any`. I faced issues with reloading the app, resulting in errors:
```
ERROR  Error: Exception in HostObject::get for prop 'RNCSafeAreaContext': java.lang.NullPointerException: null cannot be cast to non-null type kotlin.Any, js engine: hermes
```

I'm unsure of the expected behavior when `getInitialWindowMetrics` returns null, but the current exception doesn't provide enough information.

## Test Plan

- Tested in expo app ✅ 
