### PR TITLE
fix: use kotlin compatible getType

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewShadowNode.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewShadowNode.kt
@@ -143,7 +143,7 @@ class SafeAreaViewShadowNode : LayoutShadowNode() {
   override fun setPaddings(index: Int, padding: Dynamic) {
     val spacingType = ViewProps.PADDING_MARGIN_SPACING_TYPES[index]
     mPaddings[spacingType] =
-        if (padding.type == ReadableType.Number) padding.asDouble().toFloat() else Float.NaN
+        if (padding.getType() == ReadableType.Number) padding.asDouble().toFloat() else Float.NaN
     super.setPaddings(index, padding)
     mNeedsUpdate = true
   }
@@ -163,7 +163,7 @@ class SafeAreaViewShadowNode : LayoutShadowNode() {
   override fun setMargins(index: Int, margin: Dynamic) {
     val spacingType = ViewProps.PADDING_MARGIN_SPACING_TYPES[index]
     mMargins[spacingType] =
-        if (margin.type == ReadableType.Number) margin.asDouble().toFloat() else Float.NaN
+        if (margin.getType() == ReadableType.Number) margin.asDouble().toFloat() else Float.NaN
     super.setMargins(index, margin)
     mNeedsUpdate = true
   }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
PR adding compatibility for RN `0.75.0-rc.2`. Since `Dynamic` class has been migrated to Kotlin: https://github.com/facebook/react-native/blob/e320ab47cf855f2e5de74ea448ec292cf0bbb29a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/Dynamic.kt, the name of function to use is strictly `getType`. It is compatible with previous versions so should be safe to just merge.


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
