### PR TITLE
Revert "fix: use kotlin compatible getType"

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewShadowNode.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaViewShadowNode.kt
@@ -143,7 +143,7 @@ class SafeAreaViewShadowNode : LayoutShadowNode() {
   override fun setPaddings(index: Int, padding: Dynamic) {
     val spacingType = ViewProps.PADDING_MARGIN_SPACING_TYPES[index]
     mPaddings[spacingType] =
-        if (padding.getType() == ReadableType.Number) padding.asDouble().toFloat() else Float.NaN
+        if (padding.type == ReadableType.Number) padding.asDouble().toFloat() else Float.NaN
     super.setPaddings(index, padding)
     mNeedsUpdate = true
   }
@@ -163,7 +163,7 @@ class SafeAreaViewShadowNode : LayoutShadowNode() {
   override fun setMargins(index: Int, margin: Dynamic) {
     val spacingType = ViewProps.PADDING_MARGIN_SPACING_TYPES[index]
     mMargins[spacingType] =
-        if (margin.getType() == ReadableType.Number) margin.asDouble().toFloat() else Float.NaN
+        if (margin.type == ReadableType.Number) margin.asDouble().toFloat() else Float.NaN
     super.setMargins(index, margin)
     mNeedsUpdate = true
   }


### PR DESCRIPTION
Reverts th3rdwave/react-native-safe-area-context#507 since in the newest RCs we decided to drop the `getType` syntax in favor of the old one, meaning this is no longer necessary.