### PR TITLE
fix: ts error due to react types forwardRef changes

### DIFF
--- a/src/SafeAreaContext.tsx
+++ b/src/SafeAreaContext.tsx
@@ -141,11 +141,13 @@ export type WithSafeAreaInsetsProps = {
 };
 
 export function withSafeAreaInsets<T>(
-  WrappedComponent: React.ComponentType<T & WithSafeAreaInsetsProps>,
+  WrappedComponent: React.ComponentType<
+    (React.PropsWithoutRef<T> | T) & WithSafeAreaInsetsProps
+  >,
 ): React.ForwardRefExoticComponent<
   React.PropsWithoutRef<T> & React.RefAttributes<unknown>
 > {
-  return React.forwardRef((props: T, ref: React.Ref<unknown>) => {
+  return React.forwardRef<unknown, T>((props, ref) => {
     const insets = useSafeAreaInsets();
     return <WrappedComponent {...props} insets={insets} ref={ref} />;
   });


### PR DESCRIPTION
## Summary

Due to changes to forwardRef render function with @types/react 18.3.5, `withSafeAreaInsets` was throwing TS error.
```typescript
+ render: ForwardRefRenderFunction<T, PropsWithoutRef<P>>,
- render: ForwardRefRenderFunction<T, P>,
``` 

Closes #526 

## Test Plan

Not affected.
Tested on =18.3.5 and <= 18.3.4
