### PR TITLE
fix: support RN 0.76

### DIFF
--- a/android/src/main/jni/CMakeLists.txt
+++ b/android/src/main/jni/CMakeLists.txt
@@ -37,25 +37,37 @@ target_include_directories(
   ${LIB_ANDROID_GENERATED_COMPONENTS_DIR}
 )
 
-target_link_libraries(
-  ${LIB_TARGET_NAME}
-  fbjni
-  folly_runtime
-  glog
-  jsi
-  react_codegen_rncore
-  react_debug
-  react_nativemodule_core
-  react_render_core
-  react_render_debug
-  react_render_graphics
-  react_render_mapbuffer
-  react_render_componentregistry
-  react_utils
-  rrc_view
-  turbomodulejsijni
-  yoga
-)
+# https://github.com/react-native-community/discussions-and-proposals/discussions/816
+# This if-then-else can be removed once this library does not support version below 0.76
+if (REACTNATIVE_MERGED_SO)
+  target_link_libraries(
+          ${LIB_TARGET_NAME}
+          fbjni
+          jsi
+          reactnative
+  )
+else()
+  target_link_libraries(
+          ${LIB_TARGET_NAME}
+          fbjni
+          folly_runtime
+          glog
+          jsi
+          react_codegen_rncore
+          react_debug
+          react_nativemodule_core
+          react_render_core
+          react_render_debug
+          react_render_graphics
+          react_render_mapbuffer
+          react_render_componentregistry
+          react_utils
+          rrc_view
+          turbomodulejsijni
+          yoga
+  )
+endif()
+
 
 target_compile_options(
   ${LIB_TARGET_NAME}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

the recently released 4.11.1 won't build when installed into a RN 0.76 project, due to breaking changes described in https://github.com/react-native-community/discussions-and-proposals/discussions/816

This PR fixes the build in a backward-compatible way, as recommended in the link above

This is similar to https://github.com/callstack/react-native-slider/pull/660


## Test Plan

will add soon