### PR TITLE
feat: Use `BaseReactPackage` instead of `TurboReactPackage`

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaContextPackage.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaContextPackage.kt
@@ -1,6 +1,6 @@
 package com.th3rdwave.safeareacontext
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.bridge.NativeModule
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.annotations.ReactModule
@@ -8,9 +8,9 @@ import com.facebook.react.module.model.ReactModuleInfo
 import com.facebook.react.module.model.ReactModuleInfoProvider
 import com.facebook.react.uimanager.ViewManager
 
-// Fool autolinking for older versions that do not support TurboReactPackage.
+// Fool autolinking for older versions that do not support BaseReactPackage.
 // public class SafeAreaContextPackage implements ReactPackage {
-class SafeAreaContextPackage : TurboReactPackage() {
+class SafeAreaContextPackage : BaseReactPackage() {
   override fun getModule(name: String, reactContext: ReactApplicationContext): NativeModule? {
     return when (name) {
       SafeAreaContextModule.NAME -> SafeAreaContextModule(reactContext)


### PR DESCRIPTION
This is required for RN 0.77 apparently. TurboReactPackage is deprecated on new arch. No idea why.

I am not sure about backwards compatibility either, sorry.

Feel free to close this PR if this isn't backwards compatible.

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
