### PR TITLE
refactor: remove deprecated ReactModuleInfo parameter

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaContextPackage.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaContextPackage.kt
@@ -29,8 +29,6 @@ class SafeAreaContextPackage : BaseReactPackage() {
               moduleClass.name,
               true,
               reactModule.needsEagerInit,
-              /** TODO remove the parameter once support for RN < 0.73 is dropped */
-              reactModule.hasConstants,
               reactModule.isCxxModule,
               BuildConfig.IS_NEW_ARCHITECTURE_ENABLED)
     }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

As the comment explains, that parameter can now be dropped.

related: https://github.com/facebook/react-native/pull/39459

## Test Plan

Built locally with this change.
