### PR TITLE
feat: support for RN 0.77 & old architecture

### DIFF
--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNCSafeAreaProviderManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNCSafeAreaProviderManagerDelegate.java
@@ -11,12 +11,13 @@ package com.facebook.react.viewmanagers;
 
 import android.view.View;
 import androidx.annotation.Nullable;
+import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
-import com.facebook.react.uimanager.BaseViewManagerInterface;
+import com.facebook.react.uimanager.LayoutShadowNode;
 
 public class RNCSafeAreaProviderManagerDelegate<
         T extends View,
-        U extends BaseViewManagerInterface<T> & RNCSafeAreaProviderManagerInterface<T>>
+        U extends BaseViewManager<T, ? extends LayoutShadowNode> & RNCSafeAreaProviderManagerInterface<T>>
     extends BaseViewManagerDelegate<T, U> {
   public RNCSafeAreaProviderManagerDelegate(U viewManager) {
     super(viewManager);

--- a/android/src/paper/java/com/facebook/react/viewmanagers/RNCSafeAreaViewManagerDelegate.java
+++ b/android/src/paper/java/com/facebook/react/viewmanagers/RNCSafeAreaViewManagerDelegate.java
@@ -12,11 +12,12 @@ package com.facebook.react.viewmanagers;
 import android.view.View;
 import androidx.annotation.Nullable;
 import com.facebook.react.bridge.ReadableMap;
+import com.facebook.react.uimanager.BaseViewManager;
 import com.facebook.react.uimanager.BaseViewManagerDelegate;
-import com.facebook.react.uimanager.BaseViewManagerInterface;
+import com.facebook.react.uimanager.LayoutShadowNode;
 
 public class RNCSafeAreaViewManagerDelegate<
-        T extends View, U extends BaseViewManagerInterface<T> & RNCSafeAreaViewManagerInterface<T>>
+        T extends View, U extends BaseViewManager<T, ? extends LayoutShadowNode> & RNCSafeAreaViewManagerInterface<T>>
     extends BaseViewManagerDelegate<T, U> {
   public RNCSafeAreaViewManagerDelegate(U viewManager) {
     super(viewManager);


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Hey, I'm adding support for RN 0.77 in `react-native-screens` https://github.com/software-mansion/react-native-screens/pull/2581 and I stumbled on issue with RNSAC.

Basically `BaseViewManagerInterface` [has been removed from `react-native`](https://github.com/facebook/react-native/pull/46809) 
and view manager interfaces & delegates shipped for old arch purposes are no longer valid with 0.77. [The PR](https://github.com/facebook/react-native/pull/46809) claims
that this change should be backward compatible with older RN versions for old architecture.

I've included the patch I'm using in `react-native-screens` for `react-native-safe-area-context` to make my test project build. 
Please note that some more changes might be required for full compatibility with 0.77. 

## Test Plan

I'm using this patch in `react-native-screens`, but admit that I haven't tested it in your repository.

