### PR TITLE
feat: Add Release build CI

### DIFF
--- a/.github/workflows/android-release.yml
+++ b/.github/workflows/android-release.yml
@@ -35,7 +35,7 @@ jobs:
         working-directory: example
 
       - name: Build android example app with new arch disabled
-        run: ./gradlew assembleRelease -PnewArchEnabled=false
+        run: ./gradlew assembleRelease -PnewArchEnabled=true
         working-directory: example/android
 
       - name: Upload APK to Release


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

This CI builds the Safe Area Context Example Android app everytime a new GitHub release is created.

The app will be built in **release mode**, and the resulting .apk will be uploaded and attached to the GitHub release.

We can also tweak the `on` trigger to always run it (e.g. for PRs too), but I don't think that makes sense.

This is super practical because users can just download the .apk from the releases page and maybe hunt down bugs more quickly instead of time travelling through git and rebuilding each time.

Also, this should probably reproduce the bug I was talking to Janic about in my Nitro CIs.

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->


## Test Plan

Create a GitHub release and wait for this to build.

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
