### PR TITLE
fix: Add missing event dispatcher for tvOS and macOS in legacy arch

### DIFF
--- a/ios/RNCSafeAreaProvider.m
+++ b/ios/RNCSafeAreaProvider.m
@@ -23,10 +23,9 @@
   RCTAssertParam(eventDispatcher);
 
   if ((self = [super initWithFrame:CGRectZero])) {
-#if !TARGET_OS_TV && !TARGET_OS_OSX
-
     _eventDispatcher = eventDispatcher;
 
+#if !TARGET_OS_TV && !TARGET_OS_OSX
     [NSNotificationCenter.defaultCenter addObserver:self
                                            selector:@selector(invalidateSafeAreaInsets)
                                                name:UIKeyboardDidShowNotification


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

https://github.com/AppAndFlow/react-native-safe-area-context/pull/592 has brought _eventDispatcher, but it's value is never set on tvOS and macOS as the assignment is inside a platform-specific `#if`


## Test Plan

Run an app with SafeAreaProvider on legacy arch. Insets should be available.