### PR TITLE
chore(docs): Fix broken View prop links in API docs

### DIFF
--- a/docs/docs/api/safe-area-listener.mdx
+++ b/docs/docs/api/safe-area-listener.mdx
@@ -28,7 +28,7 @@ function SomeComponent() {
 
 ### Props
 
-Accepts all [View](https://reactnative.dev/view#props) props.
+Accepts all [View](https://reactnative.dev/docs/view#props) props.
 
 #### `onChange`
 

--- a/docs/docs/api/safe-area-provider.mdx
+++ b/docs/docs/api/safe-area-provider.mdx
@@ -20,7 +20,7 @@ function App() {
 
 ### Props
 
-Accepts all [View](https://reactnative.dev/view#props) props. Has a default style of `{flex: 1}`.
+Accepts all [View](https://reactnative.dev/docs/view#props) props. Has a default style of `{flex: 1}`.
 
 #### `initialMetrics`
 

--- a/docs/docs/api/safe-area-view.mdx
+++ b/docs/docs/api/safe-area-view.mdx
@@ -24,7 +24,7 @@ function SomeComponent() {
 
 ### Props
 
-Accepts all [View](https://reactnative.dev/view#props) props.
+Accepts all [View](https://reactnative.dev/docs/view#props) props.
 
 #### `edges`
 


### PR DESCRIPTION
Updated the View prop documentation links in safe-area-listener, safe-area-provider, and safe-area-view API docs to point to the correct URL (https://reactnative.dev/docs/view#props).

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->
This pull request updates the documentation for several components to fix the URL for the React Native `View` props reference. The links now correctly point to the official React Native documentation.

Documentation updates:

* Updated the "Props" section in `safe-area-provider.mdx` to use the correct React Native `View` props URL.
* Updated the "Props" section in `safe-area-listener.mdx` to use the correct React Native `View` props URL.
* Updated the "Props" section in `safe-area-view.mdx` to use the correct React Native `View` props URL.


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Nothing to test.