### PR TITLE
Fix WindowsInsets for apps targeting SDK 35+

### DIFF
--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaUtils.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaUtils.kt
@@ -9,6 +9,23 @@ import java.lang.IllegalArgumentException
 import kotlin.math.max
 import kotlin.math.min
 
+@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+private fun getRootWindowInsetsCompatV(rootView: View): EdgeInsets? {
+  val insets =
+      rootView.rootWindowInsets?.getInsets(
+          WindowInsets.Type.statusBars() or
+              WindowInsets.Type.displayCutout() or
+              WindowInsets.Type.navigationBars() or
+              WindowInsets.Type.captionBar() or
+              WindowInsets.Type.ime())
+          ?: return null
+  return EdgeInsets(
+      top = insets.top.toFloat(),
+      right = insets.right.toFloat(),
+      bottom = insets.bottom.toFloat(),
+      left = insets.left.toFloat())
+}
+
 @RequiresApi(Build.VERSION_CODES.R)
 private fun getRootWindowInsetsCompatR(rootView: View): EdgeInsets? {
   val insets =
@@ -53,6 +70,7 @@ private fun getRootWindowInsetsCompatBase(rootView: View): EdgeInsets? {
 
 private fun getRootWindowInsetsCompat(rootView: View): EdgeInsets? {
   return when {
+    Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM -> getRootWindowInsetsCompatV(rootView)
     Build.VERSION.SDK_INT >= Build.VERSION_CODES.R -> getRootWindowInsetsCompatR(rootView)
     Build.VERSION.SDK_INT >= Build.VERSION_CODES.M -> getRootWindowInsetsCompatM(rootView)
     else -> getRootWindowInsetsCompatBase(rootView)


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

This change fixes the following issue for apps targeting SDK 35+
https://github.com/facebook/react-native/issues/49759
 
Technical details:

> Before targeting SDK 35, using `android:windowSoftInputMode=”adjustResize”` was all you needed to maintain focus on — for example — an `EditText` in a `RecyclerView` when opening an IME. With `“adjustResize”`, the framework treated the IME as the system window, and the window’s root views were padded so content avoids the system window.
>
> After targeting SDK 35, you must also account for the IME using `ViewCompat.setOnApplyWindowInsetsListener` and `WindowInsetsCompat.Type.ime()` because the framework will not pad the window’s root views.

source: https://medium.com/androiddevelopers/insets-handling-tips-for-android-15s-edge-to-edge-enforcement-872774e8839b

## Test Plan

Reproducible project can be found here:
https://github.com/dprevost-LMI/rn81/tree/issue-497590-KeyboardAvoidingView-hide-input-under-SDK35

Adjust `SafeAreaView` style by removing `height` and changing `paddingBottom` to 32.

Without the fix `TextInput` is hidden whenever a soft keyboard is shown on SDK 35+, after the fix `TextInput` is correctly placed on top of the keyboard.

|Keyboard hidden|Current behavior|Fix applied|
|---|---|---|
|<img src="https://github.com/user-attachments/assets/cfdf2f2c-81aa-4594-aadf-e4616f22f735" />| <img src="https://github.com/user-attachments/assets/0443b090-38b1-4156-92da-0abcf19d5981" />|<img src="https://github.com/user-attachments/assets/064ff903-c66e-4f42-b029-f76b9ad569e6" />|
