### PR TITLE
chore(mock): remove unused react import

### DIFF
--- a/jest/mock.tsx
+++ b/jest/mock.tsx
@@ -1,5 +1,5 @@
 import { jest } from '@jest/globals';
-import React, { useContext } from 'react';
+import { useContext } from 'react';
 import type { Metrics } from '../src/SafeArea.types';
 import type {
   SafeAreaProviderProps,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

Enabling [noUnusedLocals](https://www.typescriptlang.org/tsconfig/#noUnusedParameters) reports:
```
../../node_modules/react-native-safe-area-context/jest/mock.tsx:2:8 - error TS6133: 'React' is declared but its value is never read.

2 import React, { useContext } from 'react';
         ~~~~~
``` 
This is a valid case because React import is no longer necessary, see https://arc.net/l/quote/pputites. Also, it is covered in this article https://arc.net/l/quote/ptrxehpi.


## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
