### PR TITLE
fix: make `SafeAreaView` respect `edges` param on web

### DIFF
--- a/src/SafeAreaView.web.tsx
+++ b/src/SafeAreaView.web.tsx
@@ -22,13 +22,13 @@ function getEdgeValue(
   mode: EdgeMode | undefined,
 ) {
   switch (mode) {
-    case 'off':
-      return current;
     case 'maximum':
       return Math.max(current, inset);
     case 'additive':
-    default:
       return current + inset;
+    case 'off':
+    default:
+      return current;
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The following code works fine on Android and iOS, but on Web the padding will be set to all edges despite what we set. When `getEdgeValue` is called with the third value `undefined`, which means the inset is not required, it will apply inset incorrectly.

```tsx
import { SafeAreaView } from 'react-native-safe-area-context';

<SafeAreaView edges={['bottom']}>
    ...
</SafeAreaView>
```

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
Use the latest code to run on web to se if edges are applied properly.