### PR TITLE
Update broken React Native View prop links in API documentation

### DIFF
--- a/docs/docs/api/safe-area-listener.mdx
+++ b/docs/docs/api/safe-area-listener.mdx
@@ -28,7 +28,7 @@ function SomeComponent() {
 
 ### Props
 
-Accepts all [View](https://reactnative.dev/view#props) props.
+Accepts all [View](https://reactnative.dev/docs/view) props.
 
 #### `onChange`
 

--- a/docs/docs/api/safe-area-provider.mdx
+++ b/docs/docs/api/safe-area-provider.mdx
@@ -20,7 +20,7 @@ function App() {
 
 ### Props
 
-Accepts all [View](https://reactnative.dev/view#props) props. Has a default style of `{flex: 1}`.
+Accepts all [View](https://reactnative.dev/docs/view) props. Has a default style of `{flex: 1}`.
 
 #### `initialMetrics`
 

--- a/docs/docs/api/safe-area-view.mdx
+++ b/docs/docs/api/safe-area-view.mdx
@@ -24,7 +24,7 @@ function SomeComponent() {
 
 ### Props
 
-Accepts all [View](https://reactnative.dev/view#props) props.
+Accepts all [View](https://reactnative.dev/docs/view) props.
 
 #### `edges`
 


### PR DESCRIPTION
## Summary

These links were linking to the old docs. Updated them to point at the new docs.
