### PR TITLE
fix(ios): guard +load with #ifdef RCT_DYNAMIC_FRAMEWORKS

### DIFF
--- a/ios/Fabric/RNCSafeAreaProviderComponentView.mm
+++ b/ios/Fabric/RNCSafeAreaProviderComponentView.mm
@@ -21,10 +21,12 @@ using namespace facebook::react;
 }
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load
 {
   [super load];
 }
+#endif
 
 - (instancetype)initWithFrame:(CGRect)frame
 {

--- a/ios/Fabric/RNCSafeAreaViewComponentView.mm
+++ b/ios/Fabric/RNCSafeAreaViewComponentView.mm
@@ -24,10 +24,12 @@ using namespace facebook::react;
 }
 
 // Needed because of this: https://github.com/facebook/react-native/pull/37274
+#ifdef RCT_DYNAMIC_FRAMEWORKS
 + (void)load
 {
   [super load];
 }
+#endif
 
 - (instancetype)initWithFrame:(CGRect)frame
 {


### PR DESCRIPTION
## Summary

The `+load` methods in `RNCSafeAreaProviderComponentView` and `RNCSafeAreaViewComponentView` are unconditional, but their parent `RCTViewComponentView` correctly guards its `+load` behind `#ifdef RCT_DYNAMIC_FRAMEWORKS`.

Without the guard, these `+load` methods run even when dynamic frameworks are not used, causing conflicts with third-party SDKs (e.g. Akamai BMP) that also use `+load` — particularly on x86_64 simulators where the load order differs from arm64.

This matches the pattern used by React Native core in `RCTViewComponentView.mm` (see facebook/react-native#37274).

## Test plan

- Build xcframework with static linking (no `USE_FRAMEWORKS=dynamic`)
- Verify `RNCSafeAreaProviderComponentView +load` and `RNCSafeAreaViewComponentView +load` are not in the binary (`nm` check)
- Run on x86_64 simulator alongside Akamai BMP — no crash at launch
- Run on arm64 simulator — safe area context works normally