### PR TITLE
fix: use WindowInsetsCompat to exclude keyboard insets on Android API 23-29

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -121,4 +121,5 @@ def kotlin_version = getExtOrDefault('kotlinVersion', project.properties['RNSAC_
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation 'androidx.core:core-ktx:1.9.0'
 }

--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaUtils.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaUtils.kt
@@ -5,6 +5,8 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.WindowInsets
 import androidx.annotation.RequiresApi
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import java.lang.IllegalArgumentException
 import kotlin.math.max
 import kotlin.math.min
@@ -28,15 +30,31 @@ private fun getRootWindowInsetsCompatR(rootView: View): EdgeInsets? {
 @RequiresApi(Build.VERSION_CODES.M)
 @Suppress("DEPRECATION")
 private fun getRootWindowInsetsCompatM(rootView: View): EdgeInsets? {
+  // Use WindowInsetsCompat to reliably exclude IME (keyboard) insets on API 23-29.
+  // The deprecated min(systemWindowInsetBottom, stableInsetBottom) approach can
+  // incorrectly report keyboard height as the bottom inset on some Android 10
+  // devices (e.g. Samsung One UI, Nokia with stock Android), causing SafeAreaView
+  // to add paddingBottom equal to the keyboard height and push screen content up.
+  // WindowInsetsCompat.Type.navigationBars() explicitly excludes IME insets,
+  // matching the behaviour of getRootWindowInsetsCompatR on API 30+.
+  val windowInsetsCompat = ViewCompat.getRootWindowInsets(rootView)
+  if (windowInsetsCompat != null) {
+    val insets =
+        windowInsetsCompat.getInsets(
+            WindowInsetsCompat.Type.statusBars() or
+                WindowInsetsCompat.Type.displayCutout() or
+                WindowInsetsCompat.Type.navigationBars())
+    return EdgeInsets(
+        top = insets.top.toFloat(),
+        right = insets.right.toFloat(),
+        bottom = insets.bottom.toFloat(),
+        left = insets.left.toFloat())
+  }
+  // Fallback for cases where ViewCompat.getRootWindowInsets() is unavailable.
   val insets = rootView.rootWindowInsets ?: return null
   return EdgeInsets(
       top = insets.systemWindowInsetTop.toFloat(),
       right = insets.systemWindowInsetRight.toFloat(),
-      // System insets are more reliable to account for notches but the
-      // system inset for bottom includes the soft keyboard which we don't
-      // want to be consistent with iOS. Using the min value makes sure we
-      // never get the keyboard offset while still working with devices that
-      // hide the navigation bar.
       bottom = min(insets.systemWindowInsetBottom, insets.stableInsetBottom).toFloat(),
       left = insets.systemWindowInsetLeft.toFloat())
 }

--- a/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaUtils.kt
+++ b/android/src/main/java/com/th3rdwave/safeareacontext/SafeAreaUtils.kt
@@ -30,32 +30,24 @@ private fun getRootWindowInsetsCompatR(rootView: View): EdgeInsets? {
 @RequiresApi(Build.VERSION_CODES.M)
 @Suppress("DEPRECATION")
 private fun getRootWindowInsetsCompatM(rootView: View): EdgeInsets? {
-  // Use WindowInsetsCompat to reliably exclude IME (keyboard) insets on API 23-29.
+  val insets = rootView.rootWindowInsets ?: return null
+  // Use WindowInsetsCompat to calculate the bottom inset without keyboard height.
   // The deprecated min(systemWindowInsetBottom, stableInsetBottom) approach can
   // incorrectly report keyboard height as the bottom inset on some Android 10
   // devices (e.g. Samsung One UI, Nokia with stock Android), causing SafeAreaView
   // to add paddingBottom equal to the keyboard height and push screen content up.
-  // WindowInsetsCompat.Type.navigationBars() explicitly excludes IME insets,
-  // matching the behaviour of getRootWindowInsetsCompatR on API 30+.
-  val windowInsetsCompat = ViewCompat.getRootWindowInsets(rootView)
-  if (windowInsetsCompat != null) {
-    val insets =
-        windowInsetsCompat.getInsets(
-            WindowInsetsCompat.Type.statusBars() or
-                WindowInsetsCompat.Type.displayCutout() or
-                WindowInsetsCompat.Type.navigationBars())
-    return EdgeInsets(
-        top = insets.top.toFloat(),
-        right = insets.right.toFloat(),
-        bottom = insets.bottom.toFloat(),
-        left = insets.left.toFloat())
-  }
-  // Fallback for cases where ViewCompat.getRootWindowInsets() is unavailable.
-  val insets = rootView.rootWindowInsets ?: return null
+  // WindowInsetsCompat.Type.navigationBars() explicitly excludes IME insets.
+  val bottomInset =
+      ViewCompat.getRootWindowInsets(rootView)
+          ?.getInsets(
+              WindowInsetsCompat.Type.navigationBars() or WindowInsetsCompat.Type.displayCutout())
+          ?.bottom
+          ?.toFloat()
+          ?: min(insets.systemWindowInsetBottom, insets.stableInsetBottom).toFloat()
   return EdgeInsets(
       top = insets.systemWindowInsetTop.toFloat(),
       right = insets.systemWindowInsetRight.toFloat(),
-      bottom = min(insets.systemWindowInsetBottom, insets.stableInsetBottom).toFloat(),
+      bottom = bottomInset,
       left = insets.systemWindowInsetLeft.toFloat())
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The two fields below are mandatory. -->

## Summary

On Android API 23–29 (Android 6–10), `getRootWindowInsetsCompatM` uses the deprecated `min(systemWindowInsetBottom, stableInsetBottom)` to exclude keyboard height from the bottom inset. On some Android 10 devices (confirmed on Samsung One UI and Nokia with stock Android 10), `stableInsetBottom` incorrectly reports the keyboard height, causing `SafeAreaView` to add `paddingBottom` equal to the keyboard height. This pushes the entire screen content upward whenever a `TextInput` is focused — even when `windowSoftInputMode` is set to `adjustNothing`.

Android 11+ (`getRootWindowInsetsCompatR`) is unaffected because `WindowInsets.Type.navigationBars()` explicitly excludes IME insets by design.

**Fix:** only the bottom inset calculation is changed. `top`, `right`, and `left` continue to use the existing `systemWindowInset*` values unchanged. The bottom inset is now obtained via `ViewCompat.getRootWindowInsets()` + `WindowInsetsCompat.Type.navigationBars()`, which correctly excludes keyboard insets on API 23–29 via the AndroidX compat layer. The original `min()` approach is kept as a fallback.

`androidx.core:core-ktx` is also added as an explicit dependency (it was previously only available transitively via `react-native`).

## Test Plan

Tested on:
- Samsung Galaxy (One UI, Android 10) — bottom buttons no longer pushed up when keyboard opens ✅
- Nokia 7 Plus (stock Android 10) — same ✅
- Android 11+ — no regression ✅

To reproduce the original bug: open any screen with a `TextInput` and a fixed bottom button inside a `SafeAreaView` on an Android 10 device, focus the input, and observe the button jumping upward.
