### PR TITLE
ci: add Windows matrix to Android build

### DIFF
--- a/.github/scripts/build-android.cmd
+++ b/.github/scripts/build-android.cmd
@@ -1,0 +1,7 @@
+@echo off
+setlocal
+rem subst the workspace to a short drive to avoid Windows MAX_PATH in
+rem CMake-generated object file names from autolinked codegen.
+subst W: "%GITHUB_WORKSPACE%" || exit /b 1
+cd /D W:\example\android || exit /b 1
+call gradlew.bat assembleDebug -PnewArchEnabled=%1

--- a/.github/scripts/build-android.sh
+++ b/.github/scripts/build-android.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+new_arch="${1:-false}"
+
+if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
+  # GitHub's Windows workspace path (`D:\a\<repo>\<repo>\…`) is ~70 chars
+  # before nesting. Combined with autolinked codegen object file names (which
+  # encode the full source path), it blows past Windows' 260-char MAX_PATH
+  # limit. subst aliases the workspace to a short drive to keep paths short.
+  cmd //c "subst W: \"%GITHUB_WORKSPACE%\" && cd /D W:\\example\\android && call gradlew.bat assembleDebug -PnewArchEnabled=${new_arch}"
+else
+  cd example/android
+  ./gradlew assembleDebug -PnewArchEnabled="${new_arch}"
+fi

--- a/.github/scripts/build-android.sh
+++ b/.github/scripts/build-android.sh
@@ -4,11 +4,8 @@ set -euo pipefail
 new_arch="${1:-false}"
 
 if [[ "${RUNNER_OS:-}" == "Windows" ]]; then
-  # GitHub's Windows workspace path (`D:\a\<repo>\<repo>\…`) is ~70 chars
-  # before nesting. Combined with autolinked codegen object file names (which
-  # encode the full source path), it blows past Windows' 260-char MAX_PATH
-  # limit. subst aliases the workspace to a short drive to keep paths short.
-  cmd //c "subst W: \"%GITHUB_WORKSPACE%\" && cd /D W:\\example\\android && call gradlew.bat assembleDebug -PnewArchEnabled=${new_arch}"
+  script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+  cmd //c "$(cygpath -w "$script_dir/build-android.cmd")" "$new_arch"
 else
   cd example/android
   ./gradlew assembleDebug -PnewArchEnabled="${new_arch}"

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -18,7 +18,14 @@ on:
 
 jobs:
   android-build:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 20.x
@@ -46,7 +53,14 @@ jobs:
         run: ./gradlew assembleDebug -PnewArchEnabled=false
         working-directory: example/android
   android-build-fabric:
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    defaults:
+      run:
+        shell: bash
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 20.x

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -50,15 +50,7 @@ jobs:
         run: yarn install
         working-directory: example
       - name: Build android example app with new arch disabled
-        run: |
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            # subst the workspace to a short drive to avoid Windows MAX_PATH
-            # in CMake-generated object file names from autolinked codegen.
-            MSYS_NO_PATHCONV=1 cmd /c 'subst W: "%GITHUB_WORKSPACE%" && cd /D W:\example\android && call gradlew.bat assembleDebug -PnewArchEnabled=false'
-          else
-            cd example/android
-            ./gradlew assembleDebug -PnewArchEnabled=false
-          fi
+        run: ./.github/scripts/build-android.sh false
   android-build-fabric:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -92,12 +84,4 @@ jobs:
         run: yarn install
         working-directory: example
       - name: Build android example app with new arch enabled
-        run: |
-          if [[ "$RUNNER_OS" == "Windows" ]]; then
-            # subst the workspace to a short drive to avoid Windows MAX_PATH
-            # in CMake-generated object file names from autolinked codegen.
-            MSYS_NO_PATHCONV=1 cmd /c 'subst W: "%GITHUB_WORKSPACE%" && cd /D W:\example\android && call gradlew.bat assembleDebug -PnewArchEnabled=true'
-          else
-            cd example/android
-            ./gradlew assembleDebug -PnewArchEnabled=true
-          fi
+        run: ./.github/scripts/build-android.sh true

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -50,8 +50,16 @@ jobs:
         run: yarn install
         working-directory: example
       - name: Build android example app with new arch disabled
+        if: runner.os != 'Windows'
         run: ./gradlew assembleDebug -PnewArchEnabled=false
         working-directory: example/android
+      - name: Build android example app with new arch disabled (Windows)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          subst W: "%GITHUB_WORKSPACE%"
+          cd /D W:\example\android
+          call gradlew.bat assembleDebug -PnewArchEnabled=false
   android-build-fabric:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -85,5 +93,13 @@ jobs:
         run: yarn install
         working-directory: example
       - name: Build android example app with new arch enabled
+        if: runner.os != 'Windows'
         run: ./gradlew assembleDebug -PnewArchEnabled=true
         working-directory: example/android
+      - name: Build android example app with new arch enabled (Windows)
+        if: runner.os == 'Windows'
+        shell: cmd
+        run: |
+          subst W: "%GITHUB_WORKSPACE%"
+          cd /D W:\example\android
+          call gradlew.bat assembleDebug -PnewArchEnabled=true

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -50,16 +50,15 @@ jobs:
         run: yarn install
         working-directory: example
       - name: Build android example app with new arch disabled
-        if: runner.os != 'Windows'
-        run: ./gradlew assembleDebug -PnewArchEnabled=false
-        working-directory: example/android
-      - name: Build android example app with new arch disabled (Windows)
-        if: runner.os == 'Windows'
-        shell: cmd
         run: |
-          subst W: "%GITHUB_WORKSPACE%"
-          cd /D W:\example\android
-          call gradlew.bat assembleDebug -PnewArchEnabled=false
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            # subst the workspace to a short drive to avoid Windows MAX_PATH
+            # in CMake-generated object file names from autolinked codegen.
+            MSYS_NO_PATHCONV=1 cmd /c 'subst W: "%GITHUB_WORKSPACE%" && cd /D W:\example\android && call gradlew.bat assembleDebug -PnewArchEnabled=false'
+          else
+            cd example/android
+            ./gradlew assembleDebug -PnewArchEnabled=false
+          fi
   android-build-fabric:
     runs-on: ${{ matrix.os }}
     strategy:
@@ -93,13 +92,12 @@ jobs:
         run: yarn install
         working-directory: example
       - name: Build android example app with new arch enabled
-        if: runner.os != 'Windows'
-        run: ./gradlew assembleDebug -PnewArchEnabled=true
-        working-directory: example/android
-      - name: Build android example app with new arch enabled (Windows)
-        if: runner.os == 'Windows'
-        shell: cmd
         run: |
-          subst W: "%GITHUB_WORKSPACE%"
-          cd /D W:\example\android
-          call gradlew.bat assembleDebug -PnewArchEnabled=true
+          if [[ "$RUNNER_OS" == "Windows" ]]; then
+            # subst the workspace to a short drive to avoid Windows MAX_PATH
+            # in CMake-generated object file names from autolinked codegen.
+            MSYS_NO_PATHCONV=1 cmd /c 'subst W: "%GITHUB_WORKSPACE%" && cd /D W:\example\android && call gradlew.bat assembleDebug -PnewArchEnabled=true'
+          else
+            cd example/android
+            ./gradlew assembleDebug -PnewArchEnabled=true
+          fi


### PR DESCRIPTION
## Summary

Adds `windows-latest` to the Android build matrix so we can validate whether [#691](https://github.com/AppAndFlow/react-native-safe-area-context/issues/691) is a problem in this library or in the reporter's environment.

The report is a CMake link failure when building `react_codegen_safeareacontext.so` on Windows with RN 0.82.1 Fabric: every missing symbol is from libc++_shared / libc++abi (`std::__ndk1::basic_string`, `__cxa_*`, `operator new/delete`, `vtable for std::exception`, …), which suggests the C++ stdlib is not being linked into the codegen library on Windows. Without a Windows machine it's not possible to tell whether this reproduces against our example app or is specific to the reporter's setup.

Both `android-build` (Paper) and `android-build-fabric` (Fabric) jobs now run on Ubuntu and Windows. `defaults.run.shell: bash` is set so `./gradlew` works the same way on both runners — GitHub-hosted Windows runners ship Git Bash. `fail-fast: false` keeps the existing Ubuntu coverage green even if the Windows job is broken.

The example app currently pins `react-native@^0.80.1` while the issue is reported against 0.82.1; if the Windows job passes here we'll still need to confirm against 0.82 separately, but a green Windows build on 0.80 + Fabric would already be a strong signal that the codegen CMakeLists is fine and the failure is environmental.

## Test Plan

- CI runs the four-cell matrix (Paper/Fabric × Ubuntu/Windows).
- Ubuntu cells should stay green (no behavioural change).
- Windows cells: observe whether they reproduce the link error from #691, or pass.